### PR TITLE
Fix players spawning at Y = 0 after teleportation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,8 @@ dependencies {
     deobfCompile "mezz.jei:jei_1.12.2:+"
     deobfCompile "mcp.mobius.waila:Hwyla:1.8.26-B41_1.12.2"
     deobfCompile "mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.4.+"
+
+    testImplementation "junit:junit:4.13.1"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
     }
     maven {
         name = "Hwyla Maven"
-        url  "http://tehnut.info/maven"
+        url  "http://maven.tehnut.info"
     }
     maven {
         name = "TOP Maven"

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     deobfCompile "mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.4.+"
 
     testImplementation "junit:junit:4.13.1"
+    testImplementation "org.hamcrest:hamcrest:2.2"
 }
 
 processResources {

--- a/src/main/java/jackyy/dimensionaledibles/util/TeleporterHandler.java
+++ b/src/main/java/jackyy/dimensionaledibles/util/TeleporterHandler.java
@@ -160,11 +160,11 @@ public class TeleporterHandler {
         for(int currentY = 4; currentY < world.getActualHeight(); currentY++) {
             BlockPos pos = new BlockPos(x, currentY, z);
             boolean isBlockBelowSolid = world.getBlockState(pos.down()).isSideSolid(world, pos.down(), EnumFacing.UP);
-            boolean isLegBlockSolid = world.getBlockState(pos).isNormalCube();
-            boolean isChestBlockSolid = world.getBlockState(pos.up()).isNormalCube();
+            boolean isLegBlockFree = world.getBlockState(pos).getBlock().isAir(world.getBlockState(pos), world, pos);
+            boolean isChestBlockFree = world.getBlockState(pos.up()).getBlock().isAir(world.getBlockState(pos.up()), world, pos);
 
             //Check to see if the block below the player's feet is solid, and if the player has a two block spawning area
-            if(isBlockBelowSolid && !isLegBlockSolid && !isChestBlockSolid) {
+            if(isBlockBelowSolid && isChestBlockFree && isLegBlockFree) {
                 //The first instance of a possible spawning location found
                 if(possibleY == -1) {
                     possibleY = currentY;

--- a/src/main/java/jackyy/dimensionaledibles/util/TeleporterHandler.java
+++ b/src/main/java/jackyy/dimensionaledibles/util/TeleporterHandler.java
@@ -136,26 +136,63 @@ public class TeleporterHandler {
 
     public static BlockPos getValidYSpawnPos(World world, BlockPos basePos) {
         MutableBlockPos pos = new MutableBlockPos(basePos.getX() / 8, basePos.getY(), basePos.getZ() / 8);
-        boolean foundSpawnPos = false;
-        while (!foundSpawnPos && pos.getY() < world.getActualHeight()) {
-            if (world.getBlockState(pos.add(0, -1, 0)).isSideSolid(world, pos.add(0, -1, 0), EnumFacing.UP) && !world.getBlockState(pos).isNormalCube() && !world.getBlockState(pos.add(0, 1, 0)).isNormalCube()) {
-                foundSpawnPos = true;
+        MutableBlockPos spawnPosition = new MutableBlockPos(-1, -1, -1);
+        int possibleYPosition = 0;
+
+        do {
+            //Scan the x,z coordinate point along the Y column to find a possible spawn location. Returns -1 if no location is found
+            possibleYPosition = scanColumn(world, pos.getX(), pos.getZ(), pos.getY());
+            if(possibleYPosition == -1) {
+                incrementColumn(pos, basePos);
             }
-            if (!foundSpawnPos) {
-                pos.move(EnumFacing.UP);
+            else {
+                spawnPosition.setPos(pos.getX(), possibleYPosition, pos.getZ());
             }
         }
-        while (!foundSpawnPos && pos.getY() > 0) {
-            if (pos.getY() < world.getActualHeight()) {
-                if (world.getBlockState(pos.add(0, -1, 0)).isSideSolid(world, pos.add(0, -1, 0), EnumFacing.UP) && !world.getBlockState(pos).isNormalCube() && !world.getBlockState(pos.add(0, 1, 0)).isNormalCube()) {
-                    foundSpawnPos = true;
+        while(spawnPosition.getY() == -1);
+
+        return spawnPosition;
+    }
+
+    public static int scanColumn(World world, int x, int z, int targetY) {
+        int possibleY = -1;
+        //start searching Y locations at 4 to avoid vanilla bedrock generation
+        for(int currentY = 4; currentY < world.getActualHeight(); currentY++) {
+            BlockPos pos = new BlockPos(x, currentY, z);
+            boolean isBlockBelowSolid = world.getBlockState(pos.down()).isSideSolid(world, pos.down(), EnumFacing.UP);
+            boolean isLegBlockSolid = world.getBlockState(pos).isNormalCube();
+            boolean isChestBlockSolid = world.getBlockState(pos.up()).isNormalCube();
+
+            //Check to see if the block below the player's feet is solid, and if the player has a two block spawning area
+            if(isBlockBelowSolid && !isLegBlockSolid && !isChestBlockSolid) {
+                //The first instance of a possible spawning location found
+                if(possibleY == -1) {
+                    possibleY = currentY;
+                }
+                else {
+                    //If the currentY is closer to the targetY than the current possibleY,
+                    //set that as the new possible spawning location
+                    if(Math.abs(possibleY - targetY) > Math.abs(pos.getY() - targetY)) {
+                        possibleY = currentY;
+                    }
                 }
             }
-            if (!foundSpawnPos) {
-                pos.move(EnumFacing.DOWN);
-            }
+
         }
-        return pos;
+        return possibleY;
+    }
+
+    public static void incrementColumn(MutableBlockPos currentPos, BlockPos originalPos) {
+
+        double tempPosIncrementX = originalPos.getDistance(currentPos.getX() + 1, currentPos.getY(), currentPos.getZ());
+        double tempPosIncrementZ = originalPos.getDistance(currentPos.getX(), currentPos.getY(), currentPos.getZ() + 1);
+
+        if(tempPosIncrementX > tempPosIncrementZ) {
+            currentPos.setPos(currentPos.getX(), currentPos.getY(), currentPos.getZ() + 1);
+        }
+        else {
+            currentPos.setPos(currentPos.getX() + 1, currentPos.getY(), currentPos.getZ());
+        }
     }
 
 }

--- a/src/test/java/jackyy/dimensionaledibles/util/MockHellWorldProvider.java
+++ b/src/test/java/jackyy/dimensionaledibles/util/MockHellWorldProvider.java
@@ -1,0 +1,18 @@
+package jackyy.dimensionaledibles.util;
+
+import net.minecraft.world.*;
+
+class MockHellWorldProvider extends WorldProvider
+{
+    MockHellWorldProvider()
+    {
+        nether = true;
+        this.setDimension(-1);
+    }
+
+    @Override
+    public DimensionType getDimensionType()
+    {
+        return DimensionType.NETHER;
+    }
+}

--- a/src/test/java/jackyy/dimensionaledibles/util/MockWorld.java
+++ b/src/test/java/jackyy/dimensionaledibles/util/MockWorld.java
@@ -1,0 +1,29 @@
+package jackyy.dimensionaledibles.util;
+
+import net.minecraft.profiler.*;
+import net.minecraft.world.*;
+import net.minecraft.world.chunk.*;
+import net.minecraft.world.storage.*;
+
+class MockWorld extends World
+{
+    protected MockWorld(ISaveHandler saveHandlerIn,
+                        WorldInfo info,
+                        WorldProvider providerIn,
+                        Profiler profilerIn, boolean client)
+    {
+        super(saveHandlerIn, info, providerIn, profilerIn, client);
+    }
+
+    @Override
+    protected IChunkProvider createChunkProvider()
+    {
+        return null;
+    }
+
+    @Override
+    protected boolean isChunkLoaded(int x, int z, boolean allowEmpty)
+    {
+        return false;
+    }
+}

--- a/src/test/java/jackyy/dimensionaledibles/util/TeleporterHandlerTest.java
+++ b/src/test/java/jackyy/dimensionaledibles/util/TeleporterHandlerTest.java
@@ -16,12 +16,13 @@ public class TeleporterHandlerTest
         Bootstrap.register();
     }
 
+    final IBlockState bedrock    = Blocks.BEDROCK.getDefaultState();
+    final IBlockState netherrack = Blocks.NETHERRACK.getDefaultState();
+    final IBlockState lava       = Blocks.LAVA.getDefaultState();
+    final IBlockState air        = Blocks.AIR.getDefaultState();
+
     final MockWorld solidBlockWorld = new MockWorld(null, null, new MockHellWorldProvider(), null, false)
     {
-        final IBlockState bedrock = Blocks.BEDROCK.getDefaultState();
-        final IBlockState netherrack = Blocks.NETHERRACK.getDefaultState();
-        final IBlockState air = Blocks.AIR.getDefaultState();
-
         /*
             ...
             Y>=129 Air
@@ -51,11 +52,57 @@ public class TeleporterHandlerTest
         }
     };
 
+    final MockWorld lavaWorld = new MockWorld(null, null, new MockHellWorldProvider(), null, false)
+    {
+        /*
+            ...
+            Y>=129 Air
+            Y=128 Bedrock
+            Y=127 Air
+            Y=126 Air
+            Y=125 Netherrack
+            Y=124 Lava
+            ...
+            Y=5 Lava
+            Y=4 Bedrock
+            ...
+            Y=0 Bedrock
+            Y<=-1 Air
+            ...
+         */
+        @Override
+        public IBlockState getBlockState(BlockPos pos)
+        {
+            if(pos.getY() > 128)
+                return air;
+            else if(pos.getY() == 128)
+                return bedrock;
+            else if(pos.getY() > 125)
+                return air;
+            else if(pos.getY() == 125)
+                return netherrack;
+            else if(pos.getY() <= 4)
+                return bedrock;
+            else if(pos.getY() < 0)
+                return air;
+            else
+                return lava;
+        }
+    };
+
     @Test
     public void getValidYSpawnPos_spawns_players_above_the_bottom_of_the_map()
     {
         BlockPos result = TeleporterHandler.getValidYSpawnPos(solidBlockWorld, BlockPos.ORIGIN);
 
         assertThat("Specified Y places player under the map", result.getY(), greaterThan(4));
+    }
+
+    @Test
+    public void getValidYSpawnPos_will_not_spawn_players_in_lava()
+    {
+        BlockPos result = TeleporterHandler.getValidYSpawnPos(lavaWorld, BlockPos.ORIGIN);
+
+        assertThat("Specified Y places player in lava", result.getY(), greaterThan(124));
     }
 }

--- a/src/test/java/jackyy/dimensionaledibles/util/TeleporterHandlerTest.java
+++ b/src/test/java/jackyy/dimensionaledibles/util/TeleporterHandlerTest.java
@@ -44,7 +44,10 @@ public class TeleporterHandlerTest
             if(pos.getY() <= 4)
                 return bedrock;
             if(pos.getY() < 128)
-                return netherrack;
+                if(pos.getX() > 3)
+                    return air;
+                else
+                    return netherrack;
             if(pos.getY() > 128)
                 return air;
             else // y = 128

--- a/src/test/java/jackyy/dimensionaledibles/util/TeleporterHandlerTest.java
+++ b/src/test/java/jackyy/dimensionaledibles/util/TeleporterHandlerTest.java
@@ -84,7 +84,7 @@ public class TeleporterHandlerTest
                 return air;
             else if(pos.getY() == 125)
                 return netherrack;
-            else if(pos.getY() <= 4)
+            else if(pos.getY() <= 4 && pos.getY() >= 0)
                 return bedrock;
             else if(pos.getY() < 0)
                 return air;

--- a/src/test/java/jackyy/dimensionaledibles/util/TeleporterHandlerTest.java
+++ b/src/test/java/jackyy/dimensionaledibles/util/TeleporterHandlerTest.java
@@ -1,0 +1,61 @@
+package jackyy.dimensionaledibles.util;
+
+import net.minecraft.block.state.*;
+import net.minecraft.init.*;
+import net.minecraft.util.math.*;
+import org.junit.*;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.number.OrderingComparison.*;
+
+public class TeleporterHandlerTest
+{
+    @BeforeClass
+    public static void bootStrap()
+    {
+        Bootstrap.register();
+    }
+
+    final MockWorld solidBlockWorld = new MockWorld(null, null, new MockHellWorldProvider(), null, false)
+    {
+        final IBlockState bedrock = Blocks.BEDROCK.getDefaultState();
+        final IBlockState netherrack = Blocks.NETHERRACK.getDefaultState();
+        final IBlockState air = Blocks.AIR.getDefaultState();
+
+        /*
+            ...
+            Y>=129 Air
+            Y=128 Bedrock
+            Y=127 Netherrack
+            ...
+            Y=5 Netherrack
+            Y=4 Bedrock
+            ...
+            Y=0 Bedrock
+            Y<=-1 Air
+            ...
+         */
+        @Override
+        public IBlockState getBlockState(BlockPos pos)
+        {
+            if(pos.getY() < 0)
+                return air;
+            if(pos.getY() <= 4)
+                return bedrock;
+            if(pos.getY() < 128)
+                return netherrack;
+            if(pos.getY() > 128)
+                return air;
+            else // y = 128
+                return bedrock;
+        }
+    };
+
+    @Test
+    public void getValidYSpawnPos_spawns_players_above_the_bottom_of_the_map()
+    {
+        BlockPos result = TeleporterHandler.getValidYSpawnPos(solidBlockWorld, BlockPos.ORIGIN);
+
+        assertThat("Specified Y places player under the map", result.getY(), greaterThan(4));
+    }
+}


### PR DESCRIPTION
Fixes players being spawned at Y = 0, or on top of the Nether roof after failing to find a suitable teleportation position into the Nether. 

See #1 for the analysis. This PR is a continuation of that PR, but switched to this fork, instead of on my fork.

Notice, while testing this, I did spawn in lava one time, so it would be good if we could figure out how to include not spawning in lava as part of the 2 high empty block check.

Edit: Note an easy way to test this PR would be to set `dimPos` to null in the `getDimPos` method. This will force the creation of a new spawning location every time the player travels to the nether.