### PR TITLE
Add command to invalidate spawn locations in a dimension

### DIFF
--- a/src/main/java/jackyy/dimensionaledibles/DimensionalEdibles.java
+++ b/src/main/java/jackyy/dimensionaledibles/DimensionalEdibles.java
@@ -1,15 +1,13 @@
 package jackyy.dimensionaledibles;
 
+import jackyy.dimensionaledibles.command.DimensionalEdiblesCommand;
 import jackyy.dimensionaledibles.proxy.CommonProxy;
 import jackyy.dimensionaledibles.registry.ModBlocks;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.SidedProxy;
-import net.minecraftforge.fml.common.event.FMLFingerprintViolationEvent;
-import net.minecraftforge.fml.common.event.FMLInitializationEvent;
-import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
-import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -50,6 +48,11 @@ public class DimensionalEdibles {
     @Mod.EventHandler
     public void onFingerprintViolation(FMLFingerprintViolationEvent event) {
         logger.warn("Invalid fingerprint detected! The file " + event.getSource().getName() + " may have been modified. This will NOT be supported by the mod author!");
+    }
+
+    @Mod.EventHandler
+    public void onServerLoad(FMLServerStartingEvent event) {
+        event.registerServerCommand(new DimensionalEdiblesCommand());
     }
 
 }

--- a/src/main/java/jackyy/dimensionaledibles/command/CommandInvalidate.java
+++ b/src/main/java/jackyy/dimensionaledibles/command/CommandInvalidate.java
@@ -1,5 +1,7 @@
 package jackyy.dimensionaledibles.command;
 
+import jackyy.dimensionaledibles.registry.ModConfig;
+import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
@@ -8,25 +10,29 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
-import jackyy.dimensionaledibles.registry.ModConfig;
 
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Collections;
 import java.util.List;
 
 import static jackyy.dimensionaledibles.util.TeleporterHandler.getModNBTData;
 
-public class CommandInvalidate extends CommandBase {
-
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+public class CommandInvalidate extends CommandBase
+{
     @Override
     public String getName() {
         return "invalidate";
     }
 
     @Override
+
     public String getUsage(ICommandSender sender) {
         return "dimensionaledibles.command.invalidate.usage";
     }
@@ -37,9 +43,12 @@ public class CommandInvalidate extends CommandBase {
     }
 
     @Override
-    public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos targetPos) {
-        if (args.length == 1)
-        {
+    public List<String> getTabCompletions(MinecraftServer server,
+                                          ICommandSender sender,
+                                          String[] args,
+                                          @Nullable BlockPos targetPos)
+    {
+        if(args.length == 1) {
             String[] playerNames = server.getOnlinePlayerNames();
             return getListOfStringsMatchingLastWord(args, playerNames);
         }
@@ -47,24 +56,32 @@ public class CommandInvalidate extends CommandBase {
     }
 
     @Override
-    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
-
-        if(!(args.length == 2)) {
+    public void execute(MinecraftServer server,
+                        ICommandSender sender,
+                        String[] args) throws CommandException
+    {
+        if(args.length != 2)
             throw new WrongUsageException("dimensionaledibles.command.invalidate.usage");
-        }
 
         String playerName = args[0];
+        String dimension  = args[1];
         //Will display MC player not found error if the player does not exist
         EntityPlayerMP player = getPlayer(server, sender, playerName);
         NBTTagCompound dimensionCache = getModNBTData(player);
-        if(dimensionCache.hasKey(args[1])) {
-            dimensionCache.removeTag(args[1]);
-            sender.sendMessage(new TextComponentTranslation("dimensionaledibles.command.invalidate.success").setStyle(new Style().setColor(TextFormatting.GREEN)));
-        }
-        else {
-            sender.sendMessage(new TextComponentTranslation("dimensionaledibles.command.invalidate.failed").setStyle(new Style().setColor(TextFormatting.RED)));
-        }
+        if(dimensionCache.hasKey(dimension)) {
+            dimensionCache.removeTag(dimension);
+            sender.sendMessage(successMessage());
+        } else
+            sender.sendMessage(failMessage());
+    }
 
+    private ITextComponent successMessage() {
+        return new TextComponentTranslation("dimensionaledibles.command.invalidate.success")
+                .setStyle(new Style().setColor(TextFormatting.GREEN));
+    }
 
+    private ITextComponent failMessage() {
+        return new TextComponentTranslation("dimensionaledibles.command.invalidate.failed")
+                .setStyle(new Style().setColor(TextFormatting.RED));
     }
 }

--- a/src/main/java/jackyy/dimensionaledibles/command/CommandInvalidate.java
+++ b/src/main/java/jackyy/dimensionaledibles/command/CommandInvalidate.java
@@ -1,0 +1,50 @@
+package jackyy.dimensionaledibles.command;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.text.Style;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.server.command.CommandTreeBase;
+
+import static jackyy.dimensionaledibles.util.TeleporterHandler.getModNBTData;
+
+public class CommandInvalidate extends CommandBase {
+
+    @Override
+    public String getName() {
+        return "invalidate";
+    }
+
+    @Override
+    public String getUsage(ICommandSender sender) {
+        return "dimensionaledibles.command.invalidate.usage";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 1;
+    }
+
+    @Override
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+
+        try {
+            EntityPlayerMP player = getCommandSenderAsPlayer(sender);
+            NBTTagCompound dimensionCache = getModNBTData(player);
+            if(dimensionCache.hasKey(args[0])) {
+                dimensionCache.removeTag(args[0]);
+                sender.sendMessage(new TextComponentTranslation("dimensionaledibles.command.invalidate.success").setStyle(new Style().setColor(TextFormatting.GREEN)));
+            }
+        }
+        catch (IndexOutOfBoundsException exception) {
+            sender.sendMessage(new TextComponentTranslation("dimensionaledibles.command.invalidate.failed").setStyle(new Style().setColor(TextFormatting.RED)));
+        }
+
+
+    }
+}

--- a/src/main/java/jackyy/dimensionaledibles/command/CommandInvalidate.java
+++ b/src/main/java/jackyy/dimensionaledibles/command/CommandInvalidate.java
@@ -3,13 +3,19 @@ package jackyy.dimensionaledibles.command;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import jackyy.dimensionaledibles.registry.ModConfig;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
 
 import static jackyy.dimensionaledibles.util.TeleporterHandler.getModNBTData;
 
@@ -31,18 +37,31 @@ public class CommandInvalidate extends CommandBase {
     }
 
     @Override
+    public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos targetPos) {
+        if (args.length == 1)
+        {
+            String[] playerNames = server.getOnlinePlayerNames();
+            return getListOfStringsMatchingLastWord(args, playerNames);
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
     public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
 
-        try {
-            String playerName = args[0];
-            EntityPlayerMP player = getPlayer(server, sender, playerName);
-            NBTTagCompound dimensionCache = getModNBTData(player);
-            if(dimensionCache.hasKey(args[1])) {
-                dimensionCache.removeTag(args[1]);
-                sender.sendMessage(new TextComponentTranslation("dimensionaledibles.command.invalidate.success").setStyle(new Style().setColor(TextFormatting.GREEN)));
-            }
+        if(args.length == 0) {
+            throw new WrongUsageException("dimensionaledibles.command.invalidate.usage");
         }
-        catch (IndexOutOfBoundsException exception) {
+
+        String playerName = args[0];
+        //Will display MC player not found error if the player does not exist
+        EntityPlayerMP player = getPlayer(server, sender, playerName);
+        NBTTagCompound dimensionCache = getModNBTData(player);
+        if(dimensionCache.hasKey(args[1])) {
+            dimensionCache.removeTag(args[1]);
+            sender.sendMessage(new TextComponentTranslation("dimensionaledibles.command.invalidate.success").setStyle(new Style().setColor(TextFormatting.GREEN)));
+        }
+        else {
             sender.sendMessage(new TextComponentTranslation("dimensionaledibles.command.invalidate.failed").setStyle(new Style().setColor(TextFormatting.RED)));
         }
 

--- a/src/main/java/jackyy/dimensionaledibles/command/CommandInvalidate.java
+++ b/src/main/java/jackyy/dimensionaledibles/command/CommandInvalidate.java
@@ -32,7 +32,6 @@ public class CommandInvalidate extends CommandBase
     }
 
     @Override
-
     public String getUsage(ICommandSender sender) {
         return "dimensionaledibles.command.invalidate.usage";
     }

--- a/src/main/java/jackyy/dimensionaledibles/command/CommandInvalidate.java
+++ b/src/main/java/jackyy/dimensionaledibles/command/CommandInvalidate.java
@@ -49,7 +49,7 @@ public class CommandInvalidate extends CommandBase {
     @Override
     public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
 
-        if(args.length == 0) {
+        if(!(args.length == 2)) {
             throw new WrongUsageException("dimensionaledibles.command.invalidate.usage");
         }
 

--- a/src/main/java/jackyy/dimensionaledibles/command/CommandInvalidate.java
+++ b/src/main/java/jackyy/dimensionaledibles/command/CommandInvalidate.java
@@ -9,7 +9,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraftforge.server.command.CommandTreeBase;
+import jackyy.dimensionaledibles.registry.ModConfig;
 
 import static jackyy.dimensionaledibles.util.TeleporterHandler.getModNBTData;
 
@@ -27,17 +27,18 @@ public class CommandInvalidate extends CommandBase {
 
     @Override
     public int getRequiredPermissionLevel() {
-        return 1;
+        return ModConfig.general.operatorInvalidationLevel;
     }
 
     @Override
     public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
 
         try {
-            EntityPlayerMP player = getCommandSenderAsPlayer(sender);
+            String playerName = args[0];
+            EntityPlayerMP player = getPlayer(server, sender, playerName);
             NBTTagCompound dimensionCache = getModNBTData(player);
-            if(dimensionCache.hasKey(args[0])) {
-                dimensionCache.removeTag(args[0]);
+            if(dimensionCache.hasKey(args[1])) {
+                dimensionCache.removeTag(args[1]);
                 sender.sendMessage(new TextComponentTranslation("dimensionaledibles.command.invalidate.success").setStyle(new Style().setColor(TextFormatting.GREEN)));
             }
         }

--- a/src/main/java/jackyy/dimensionaledibles/command/DimensionalEdiblesCommand.java
+++ b/src/main/java/jackyy/dimensionaledibles/command/DimensionalEdiblesCommand.java
@@ -1,0 +1,29 @@
+package jackyy.dimensionaledibles.command;
+
+import com.google.common.collect.Lists;
+import net.minecraft.command.ICommandSender;
+import net.minecraftforge.server.command.CommandTreeBase;
+
+import java.util.List;
+
+public class DimensionalEdiblesCommand extends CommandTreeBase {
+
+    public DimensionalEdiblesCommand() {
+        addSubcommand(new CommandInvalidate());
+    }
+
+    @Override
+    public String getName() {
+        return "dimensionalEdibles";
+    }
+
+    @Override
+    public List<String> getAliases() {
+        return Lists.newArrayList("de");
+    }
+
+    @Override
+    public String getUsage(ICommandSender sender) {
+        return "dimensionaledibles.command.usage";
+    }
+}

--- a/src/main/java/jackyy/dimensionaledibles/registry/ModConfig.java
+++ b/src/main/java/jackyy/dimensionaledibles/registry/ModConfig.java
@@ -30,6 +30,10 @@ public class ModConfig {
         public boolean overworldApple = true;
         @Config.Comment("Set to true to enable Custom Cake.")
         public boolean customApple = true;
+
+        @Config.Comment("Required operator level to invalidate stored cake spawning position")
+        @Config.RangeInt(min = 1, max = 4)
+        public int operatorInvalidationLevel = 1;
     }
 
     public static class Tweaks {

--- a/src/main/resources/assets/dimensionaledibles/lang/en_US.lang
+++ b/src/main/resources/assets/dimensionaledibles/lang/en_US.lang
@@ -26,6 +26,6 @@ dimensionaledibles.error.end_portal_disabled=§cActivation of the End Portal has
 
 #Commands
 dimensionaledibles.command.usage=Usage: /dimensionalEdibles <invalidate>
-dimensionaledibles.command.invalidate.usage=Usage: /dimensionalEdibles invalidate dimID
-dimensionaledibles.command.invalidate.failed=Usage: /dimensionalEdibles invalidate <dimID>
+dimensionaledibles.command.invalidate.usage=Usage: /dimensionalEdibles invalidate <player> <dimID>
+dimensionaledibles.command.invalidate.failed=Incorrect or unspecified parameters
 dimensionaledibles.command.invalidate.success=Successfully removed stored spawn location

--- a/src/main/resources/assets/dimensionaledibles/lang/en_US.lang
+++ b/src/main/resources/assets/dimensionaledibles/lang/en_US.lang
@@ -26,6 +26,6 @@ dimensionaledibles.error.end_portal_disabled=§cActivation of the End Portal has
 
 #Commands
 dimensionaledibles.command.usage=Usage: /dimensionalEdibles <invalidate>
-dimensionaledibles.command.invalidate.usage=Usage: /dimensionalEdibles invalidate <player> <dimID>
-dimensionaledibles.command.invalidate.failed=Incorrect or unspecified parameters
+dimensionaledibles.command.invalidate.usage=/dimensionalEdibles invalidate <player> <dimID>
+dimensionaledibles.command.invalidate.failed=Dimension not found in stored dimension cache
 dimensionaledibles.command.invalidate.success=Successfully removed stored spawn location

--- a/src/main/resources/assets/dimensionaledibles/lang/en_US.lang
+++ b/src/main/resources/assets/dimensionaledibles/lang/en_US.lang
@@ -23,3 +23,9 @@ dimensionaledibles.overworld_apple.jeidesc=Eat the apple and you'll be teleporte
 
 #Error Messages
 dimensionaledibles.error.end_portal_disabled=§cActivation of the End Portal has been disabled! Please use the End Cake instead!
+
+#Commands
+dimensionaledibles.command.usage=Usage: /dimensionalEdibles <invalidate>
+dimensionaledibles.command.invalidate.usage=Usage: /dimensionalEdibles invalidate dimID
+dimensionaledibles.command.invalidate.failed=Usage: /dimensionalEdibles invalidate <dimID>
+dimensionaledibles.command.invalidate.success=Successfully removed stored spawn location


### PR DESCRIPTION
To tag on to #3 and closes #7, this PR adds a command to invalidate the stored dimPos of the spawn point in a dimension for the player. This is useful for when the player had an invalid spawn point before the changes that went in in #3.

The syntax is `/dimensionalEdibles invalidate <dimID>`