### PR TITLE
Allow using cake while holding fuel block and cake is at full fuel

### DIFF
--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -1,47 +1,45 @@
 package jackyy.dimensionaledibles.block;
 
-import jackyy.dimensionaledibles.DimensionalEdibles;
-import jackyy.dimensionaledibles.util.ITOPInfoProvider;
-import jackyy.dimensionaledibles.util.IWailaInfoProvider;
-import mcjty.theoneprobe.api.ElementAlignment;
-import mcjty.theoneprobe.api.IProbeHitData;
-import mcjty.theoneprobe.api.IProbeInfo;
-import mcjty.theoneprobe.api.ProbeMode;
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
-import net.minecraft.block.Block;
-import net.minecraft.block.SoundType;
-import net.minecraft.block.material.Material;
-import net.minecraft.block.properties.PropertyInteger;
-import net.minecraft.block.state.BlockStateContainer;
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Items;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.stats.StatList;
-import net.minecraft.util.BlockRenderLayer;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumHand;
-import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.text.TextFormatting;
-import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
+import jackyy.dimensionaledibles.*;
+import jackyy.dimensionaledibles.util.*;
+import mcjty.theoneprobe.api.*;
+import mcp.mobius.waila.api.*;
+import net.minecraft.block.*;
+import net.minecraft.block.material.*;
+import net.minecraft.block.properties.*;
+import net.minecraft.block.state.*;
+import net.minecraft.creativetab.*;
+import net.minecraft.entity.*;
+import net.minecraft.entity.player.*;
+import net.minecraft.init.*;
+import net.minecraft.item.*;
+import net.minecraft.util.*;
+import net.minecraft.util.math.*;
+import net.minecraft.util.text.*;
+import net.minecraft.world.*;
+import net.minecraftforge.fml.relauncher.*;
 
-import java.util.List;
-import java.util.Random;
+import java.util.*;
+
+import static jackyy.dimensionaledibles.util.TeleporterHandler.*;
 
 /**
  * This is based on the vanilla cake class, but slightly modified and added
  * Waila / TOP support.
  */
-public class BlockCakeBase extends Block implements ITOPInfoProvider, IWailaInfoProvider {
+public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, IWailaInfoProvider {
 
     public static final PropertyInteger BITES = PropertyInteger.create("bites", 0, 6);
-    public static final AxisAlignedBB[] CAKE_AABB = new AxisAlignedBB[]{new AxisAlignedBB(0.0625D, 0.0D, 0.0625D, 0.9375D, 0.5D, 0.9375D), new AxisAlignedBB(0.1875D, 0.0D, 0.0625D, 0.9375D, 0.5D, 0.9375D), new AxisAlignedBB(0.3125D, 0.0D, 0.0625D, 0.9375D, 0.5D, 0.9375D), new AxisAlignedBB(0.4375D, 0.0D, 0.0625D, 0.9375D, 0.5D, 0.9375D), new AxisAlignedBB(0.5625D, 0.0D, 0.0625D, 0.9375D, 0.5D, 0.9375D), new AxisAlignedBB(0.6875D, 0.0D, 0.0625D, 0.9375D, 0.5D, 0.9375D), new AxisAlignedBB(0.8125D, 0.0D, 0.0625D, 0.9375D, 0.5D, 0.9375D)};
+    public static final AxisAlignedBB[] CAKE_AABB =
+        new AxisAlignedBB[]{
+            new AxisAlignedBB(0.0625D, 0.0D, 0.0625D, 0.9375D, 0.5D, 0.9375D),
+            new AxisAlignedBB(0.1875D, 0.0D, 0.0625D, 0.9375D, 0.5D, 0.9375D),
+            new AxisAlignedBB(0.3125D, 0.0D, 0.0625D, 0.9375D, 0.5D, 0.9375D),
+            new AxisAlignedBB(0.4375D, 0.0D, 0.0625D, 0.9375D, 0.5D, 0.9375D),
+            new AxisAlignedBB(0.5625D, 0.0D, 0.0625D, 0.9375D, 0.5D, 0.9375D),
+            new AxisAlignedBB(0.6875D, 0.0D, 0.0625D, 0.9375D, 0.5D, 0.9375D),
+            new AxisAlignedBB(0.8125D, 0.0D, 0.0625D, 0.9375D, 0.5D, 0.9375D)
+        };
 
     public BlockCakeBase() {
         super(Material.CAKE);
@@ -52,54 +50,119 @@ public class BlockCakeBase extends Block implements ITOPInfoProvider, IWailaInfo
         setCreativeTab(DimensionalEdibles.TAB);
     }
 
-    @Override @Deprecated
-    public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
+    /**
+     * Whether this cake comes pre-fueled (true) or starts empty (false)
+     */
+    abstract protected boolean isPreFueled();
+
+    /**
+     * Whether this cake should consume fuel.
+     */
+    abstract protected boolean consumesFuel();
+
+    /**
+     * Whether to use custom coordinates
+     */
+    abstract protected boolean useCustomCoordinates();
+
+    /**
+     * Custom Coordinates defined for this cake
+     */
+    abstract protected BlockPos customCoordinates();
+
+    /**
+     * Target dimension for this cake.
+     */
+    abstract protected int cakeDimension();
+
+    /**
+     * Resource name of the fuel item for this cake.
+     */
+    abstract protected String cakeFuel();
+
+    /**
+     * Whether this item should be registered.
+     */
+    abstract boolean registerItem();
+
+    @Override
+    public AxisAlignedBB getBoundingBox(IBlockState state,
+                                        IBlockAccess source,
+                                        BlockPos pos) {
         return CAKE_AABB[state.getValue(BITES)];
     }
 
-    @Override @SideOnly(Side.CLIENT) @Deprecated
-    public AxisAlignedBB getSelectedBoundingBox(IBlockState state, World worldIn, BlockPos pos) {
+    @Override
+    @SideOnly(Side.CLIENT)
+    public AxisAlignedBB getSelectedBoundingBox(IBlockState state,
+                                                World worldIn,
+                                                BlockPos pos) {
         return state.getCollisionBoundingBox(worldIn, pos);
     }
 
-    @Override @Deprecated
+    @Override
     public boolean isFullCube(IBlockState state) {
         return false;
     }
 
-    @Override @Deprecated
+    @Override
     public boolean isOpaqueCube(IBlockState state) {
         return false;
     }
 
     @Override
-    public boolean onBlockActivated(World worldIn, BlockPos pos, IBlockState state, EntityPlayer playerIn, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
-        if (playerIn.canEat(false)) {
-            playerIn.addStat(StatList.CAKE_SLICES_EATEN);
-            playerIn.getFoodStats().addStats(2, 0.1F);
-            int i = state.getValue(BITES);
-            if (i < 6) {
-                worldIn.setBlockState(pos, state.withProperty(BITES, i + 1), 3);
-            } else {
-                worldIn.setBlockToAir(pos);
+    public boolean onBlockActivated(World worldIn,
+                                    BlockPos pos,
+                                    IBlockState state,
+                                    EntityPlayer playerIn,
+                                    EnumHand hand,
+                                    EnumFacing side,
+                                    float hitX,
+                                    float hitY,
+                                    float hitZ) {
+        int meta = getMetaFromState(worldIn.getBlockState(pos)) - 1;
+        int fuelUntilFull = getMetaFromState(state);
+
+        ItemStack stack = playerIn.getHeldItem(hand);
+        if (!stack.isEmpty() &&
+            stack.getItem() == Item.REGISTRY.getObject(new ResourceLocation(this.cakeFuel())) &&
+            fuelUntilFull != 0) {
+            if (meta >= 0) {
+                worldIn.setBlockState(pos, state.withProperty(BITES, meta), 2);
+                if (!playerIn.capabilities.isCreativeMode)
+                    stack.shrink(1);
+                return true;
             }
-        }
-        return true;
+        } else if (worldIn.provider.getDimension() != this.cakeDimension())
+            if (!worldIn.isRemote) {
+                if (playerIn.capabilities.isCreativeMode || !this.consumesFuel())
+                    teleportPlayer(worldIn, playerIn);
+                else
+                    consumeCake(worldIn, pos, playerIn);
+                return true;
+            }
+        return false;
     }
 
     @Override
-    public boolean canPlaceBlockAt(World worldIn, BlockPos pos) {
+    public boolean canPlaceBlockAt(World worldIn,
+                                   BlockPos pos) {
         return super.canPlaceBlockAt(worldIn, pos) && this.canBlockStay(worldIn, pos);
     }
 
-    @Override @Deprecated
-    public void neighborChanged(IBlockState state, World worldIn, BlockPos pos, Block blockIn, BlockPos fromPos) {
+    @Override
+    public void neighborChanged(IBlockState state,
+                                World worldIn,
+                                BlockPos pos,
+                                Block blockIn,
+                                BlockPos fromPos) {
         if (!this.canBlockStay(worldIn, pos)) {
             worldIn.setBlockToAir(pos);
         }
     }
 
-    private boolean canBlockStay(World worldIn, BlockPos pos) {
+    private boolean canBlockStay(World worldIn,
+                                 BlockPos pos) {
         return worldIn.getBlockState(pos.down()).getMaterial().isSolid();
     }
 
@@ -109,16 +172,19 @@ public class BlockCakeBase extends Block implements ITOPInfoProvider, IWailaInfo
     }
 
     @Override
-    public Item getItemDropped(IBlockState state, Random rand, int fortune) {
-        return null;
+    public Item getItemDropped(IBlockState state,
+                               Random rand,
+                               int fortune) {
+        return Items.AIR;
     }
 
-    @Override @Deprecated
+    @Override
     public IBlockState getStateFromMeta(int meta) {
         return this.getDefaultState().withProperty(BITES, meta);
     }
 
-    @Override @SideOnly(Side.CLIENT)
+    @Override
+    @SideOnly(Side.CLIENT)
     public BlockRenderLayer getRenderLayer() {
         return BlockRenderLayer.CUTOUT;
     }
@@ -133,32 +199,104 @@ public class BlockCakeBase extends Block implements ITOPInfoProvider, IWailaInfo
         return new BlockStateContainer(this, BITES);
     }
 
-    @Override @Deprecated
-    public int getComparatorInputOverride(IBlockState blockState, World worldIn, BlockPos pos) {
+    @Override
+    public int getComparatorInputOverride(IBlockState blockState,
+                                          World worldIn,
+                                          BlockPos pos) {
         return (7 - blockState.getValue(BITES)) * 2;
     }
 
-    @Override @Deprecated
+    @Override
     public boolean hasComparatorInputOverride(IBlockState state) {
         return true;
     }
 
     @Override
-    public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data) {
+    public void addProbeInfo(ProbeMode mode,
+                             IProbeInfo probeInfo,
+                             EntityPlayer player,
+                             World world,
+                             IBlockState blockState,
+                             IProbeHitData data) {
         if (world.getBlockState(data.getPos()).getBlock() instanceof BlockCakeBase) {
             probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER))
-                    .item(new ItemStack(Items.CAKE))
-                    .text(TextFormatting.GREEN + "Bites: ")
-                    .progress(6 - blockState.getValue(BITES), 6);
+                     .item(new ItemStack(Items.CAKE))
+                     .text(TextFormatting.GREEN + "Bites: ")
+                     .progress(6 - blockState.getValue(BITES), 6);
         }
     }
 
     @Override
-    public List<String> getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor, IWailaConfigHandler config) {
+    public List<String> getWailaBody(ItemStack itemStack,
+                                     List<String> currentTip,
+                                     IWailaDataAccessor accessor,
+                                     IWailaConfigHandler config) {
         if (accessor.getBlockState().getBlock() instanceof BlockCakeBase) {
-            currenttip.add(TextFormatting.GRAY + "Bites: " + (6 - accessor.getBlockState().getValue(BITES)) + " / 6");
+            currentTip.add(TextFormatting.GRAY + "Bites: " + (6 - accessor.getBlockState().getValue(BITES)) + " / 6");
         }
-        return currenttip;
+        return currentTip;
     }
 
+    /**
+     * Configure the starting state of the Cake when placed.
+     */
+    @Override
+    public IBlockState getStateForPlacement(World world,
+                                            BlockPos pos,
+                                            EnumFacing facing,
+                                            float hitX,
+                                            float hitY,
+                                            float hitZ,
+                                            int meta,
+                                            EntityLivingBase placer,
+                                            EnumHand hand) {
+        return getDefaultState().withProperty(BITES, isPreFueled() ? 6 : 0);
+    }
+
+    /**
+     * Teleport the player to this cake's dimension.
+     */
+    protected void teleportPlayer(World world,
+                                  EntityPlayer player) {
+        EntityPlayerMP playerMP = (EntityPlayerMP) player;
+        BlockPos coords;
+        if (useCustomCoordinates())
+            coords = customCoordinates();
+        else
+            coords = calculateCoordinates(playerMP);
+
+        updateDimPos(playerMP, world.provider.getDimension(), playerMP.getPosition());
+        teleport(playerMP, cakeDimension(), coords, playerMP.server.getPlayerList());
+    }
+
+    /**
+     * Calculate the teleportation location in the other dimension.
+     */
+    protected BlockPos calculateCoordinates(EntityPlayerMP player) {
+        return getDimPos(player, cakeDimension(), player.getPosition());
+    }
+
+    /**
+     * The player eats the cake, then teleports.
+     */
+    protected void consumeCake(World world,
+                               BlockPos pos,
+                               EntityPlayer player) {
+        if (player.canEat(true)) {
+            int l = world.getBlockState(pos).getValue(BITES);
+            if (l < 6) {
+                player.getFoodStats().addStats(2, 0.1F);
+                world.setBlockState(pos, world.getBlockState(pos).withProperty(BITES, l + 1), 3);
+                teleportPlayer(world, player);
+            }
+        }
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void getSubBlocks(CreativeTabs tab,
+                             NonNullList<ItemStack> list) {
+        if (registerItem())
+            list.add(new ItemStack(this));
+    }
 }

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -29,7 +29,19 @@ import static jackyy.dimensionaledibles.util.TeleporterHandler.*;
  */
 public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, IWailaInfoProvider {
 
-    public static final PropertyInteger BITES = PropertyInteger.create("bites", 0, 6);
+    /** The number of bites remaining in a fully-fueled cake. */
+    public static final int MAX_BITES = 6;
+
+    /**
+     * "Bites" property for tracking damage to the cake.
+     * Zero bites is a fully-fueled cake. MAX_BITES is an empty cake.
+     */
+    public static final PropertyInteger BITES = PropertyInteger.create("bites", 0, MAX_BITES);
+
+    /**
+     * Bounding Box for cakes.
+     * Each entry in the array corresponds to a specific value of the BITES property.
+     */
     public static final AxisAlignedBB[] CAKE_AABB =
         new AxisAlignedBB[]{
             new AxisAlignedBB(0.0625D, 0.0D, 0.0625D, 0.9375D, 0.5D, 0.9375D),
@@ -222,7 +234,7 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
             probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER))
                      .item(new ItemStack(Items.CAKE))
                      .text(TextFormatting.GREEN + "Bites: ")
-                     .progress(6 - blockState.getValue(BITES), 6);
+                     .progress(MAX_BITES - blockState.getValue(BITES), MAX_BITES);
         }
     }
 
@@ -232,7 +244,8 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
                                      IWailaDataAccessor accessor,
                                      IWailaConfigHandler config) {
         if (accessor.getBlockState().getBlock() instanceof BlockCakeBase) {
-            currentTip.add(TextFormatting.GRAY + "Bites: " + (6 - accessor.getBlockState().getValue(BITES)) + " / 6");
+            currentTip.add(TextFormatting.GRAY + "Bites: " +
+                           (MAX_BITES - accessor.getBlockState().getValue(BITES)) + " / " + MAX_BITES);
         }
         return currentTip;
     }
@@ -250,7 +263,7 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
                                             int meta,
                                             EntityLivingBase placer,
                                             EnumHand hand) {
-        return getDefaultState().withProperty(BITES, isPreFueled() ? 0 : 6);
+        return getDefaultState().withProperty(BITES, isPreFueled() ? 0 : MAX_BITES);
     }
 
     /**
@@ -284,7 +297,7 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
                                EntityPlayer player) {
         if (player.canEat(true)) {
             int l = world.getBlockState(pos).getValue(BITES);
-            if (l < 6) {
+            if (l < MAX_BITES) {
                 player.getFoodStats().addStats(2, 0.1F);
                 world.setBlockState(pos, world.getBlockState(pos).withProperty(BITES, l + 1), 3);
                 teleportPlayer(world, player);

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -250,7 +250,7 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
                                             int meta,
                                             EntityLivingBase placer,
                                             EnumHand hand) {
-        return getDefaultState().withProperty(BITES, isPreFueled() ? 6 : 0);
+        return getDefaultState().withProperty(BITES, isPreFueled() ? 0 : 6);
     }
 
     /**

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
@@ -77,7 +77,8 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
                 DimensionalEdibles.logger.log(Level.ERROR, s + " is not a valid line input! The dimension ID needs to be a number!");
             }
         }
-        if (!stack.isEmpty() && stack.getItem() == Item.REGISTRY.getObject(new ResourceLocation(fuel))) {
+        int fuelUntilFull = getMetaFromState(state);
+        if (!stack.isEmpty() && stack.getItem() == Item.REGISTRY.getObject(new ResourceLocation(fuel)) && fuelUntilFull != 0) {
             if (meta >= 0) {
                 world.setBlockState(pos, state.withProperty(BITES, meta), 2);
                 if (!player.capabilities.isCreativeMode) {

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockEndCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockEndCake.java
@@ -1,26 +1,12 @@
 package jackyy.dimensionaledibles.block;
 
-import jackyy.dimensionaledibles.DimensionalEdibles;
-import jackyy.dimensionaledibles.block.tile.TileDimensionCake;
-import jackyy.dimensionaledibles.registry.ModConfig;
-import jackyy.dimensionaledibles.util.TeleporterHandler;
-import net.minecraft.block.ITileEntityProvider;
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumHand;
-import net.minecraft.util.NonNullList;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
+import jackyy.dimensionaledibles.*;
+import jackyy.dimensionaledibles.block.tile.*;
+import jackyy.dimensionaledibles.registry.*;
+import net.minecraft.block.*;
+import net.minecraft.tileentity.*;
+import net.minecraft.util.math.*;
+import net.minecraft.world.*;
 
 public class BlockEndCake extends BlockCakeBase implements ITileEntityProvider {
 
@@ -31,72 +17,44 @@ public class BlockEndCake extends BlockCakeBase implements ITileEntityProvider {
     }
 
     @Override
-    public boolean onBlockActivated(World world, BlockPos pos, IBlockState state, EntityPlayer player, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
-        int meta = getMetaFromState(world.getBlockState(pos)) - 1;
-        ItemStack stack = player.getHeldItem(hand);
-        int fuelUntilFull = getMetaFromState(state);
-
-        if (!stack.isEmpty() && stack.getItem() == Item.REGISTRY.getObject(new ResourceLocation(ModConfig.tweaks.endCake.fuel)) && fuelUntilFull != 0) {
-            if (meta >= 0) {
-                world.setBlockState(pos, state.withProperty(BITES, meta), 2);
-                if (!player.capabilities.isCreativeMode) {
-                    stack.shrink(1);
-                }
-                return true;
-            }
-        } else {
-            if (world.provider.getDimension() != 1) {
-                if (!world.isRemote) {
-                    if (player.capabilities.isCreativeMode || !ModConfig.tweaks.endCake.consumeFuel) {
-                        teleportPlayer(world, player);
-                    } else {
-                        consumeCake(world, pos, player);
-                    }
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private void teleportPlayer(World world, EntityPlayer player) {
-        EntityPlayerMP playerMP = (EntityPlayerMP) player;
-        BlockPos coords;
-        if (ModConfig.tweaks.endCake.useCustomCoords) {
-            coords = new BlockPos(ModConfig.tweaks.endCake.customCoords.x, ModConfig.tweaks.endCake.customCoords.y, ModConfig.tweaks.endCake.customCoords.z);
-        } else {
-            coords = TeleporterHandler.getDimPos(playerMP, 1, player.getPosition());
-        }
-        TeleporterHandler.updateDimPos(playerMP, world.provider.getDimension(), player.getPosition());
-        TeleporterHandler.teleport(playerMP, 1, coords.getX(), coords.getY(), coords.getZ(), playerMP.server.getPlayerList());
-    }
-
-    private void consumeCake(World world, BlockPos pos, EntityPlayer player) {
-        if (player.canEat(true)) {
-            int l = world.getBlockState(pos).getValue(BITES);
-            if (l < 6) {
-                player.getFoodStats().addStats(2, 0.1F);
-                world.setBlockState(pos, world.getBlockState(pos).withProperty(BITES, l + 1), 3);
-                teleportPlayer(world, player);
-            }
-        }
+    public TileEntity createNewTileEntity(World worldIn,
+                                          int meta) {
+        return new TileDimensionCake(cakeDimension(), "End");
     }
 
     @Override
-    public IBlockState getStateForPlacement(World world, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer, EnumHand hand) {
-        return ModConfig.tweaks.endCake.preFueled ? getDefaultState().withProperty(BITES, 0) : getDefaultState().withProperty(BITES, 6);
+    protected String cakeFuel() {
+        return ModConfig.tweaks.endCake.fuel;
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
-    public void getSubBlocks(CreativeTabs tab, NonNullList<ItemStack> list) {
-        if (ModConfig.general.endCake)
-            list.add(new ItemStack(this));
+    protected boolean useCustomCoordinates() {
+        return ModConfig.tweaks.endCake.useCustomCoords;
     }
 
     @Override
-    public TileEntity createNewTileEntity(World worldIn, int meta) {
-        return new TileDimensionCake(1, "End");
+    protected BlockPos customCoordinates() {
+        return new BlockPos(ModConfig.tweaks.endCake.customCoords.x,
+                            ModConfig.tweaks.endCake.customCoords.y,
+                            ModConfig.tweaks.endCake.customCoords.z);
     }
 
+    @Override
+    protected int cakeDimension() {
+        return 1;
+    }
+
+    @Override
+    protected boolean consumesFuel() {
+        return ModConfig.tweaks.endCake.consumeFuel;
+    }
+
+    @Override
+    protected boolean isPreFueled() {
+        return ModConfig.tweaks.endCake.preFueled;
+    }
+
+    @Override boolean registerItem() {
+        return ModConfig.general.endCake;
+    }
 }

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockEndCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockEndCake.java
@@ -34,7 +34,9 @@ public class BlockEndCake extends BlockCakeBase implements ITileEntityProvider {
     public boolean onBlockActivated(World world, BlockPos pos, IBlockState state, EntityPlayer player, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
         int meta = getMetaFromState(world.getBlockState(pos)) - 1;
         ItemStack stack = player.getHeldItem(hand);
-        if (!stack.isEmpty() && stack.getItem() == Item.REGISTRY.getObject(new ResourceLocation(ModConfig.tweaks.endCake.fuel))) {
+        int fuelUntilFull = getMetaFromState(state);
+
+        if (!stack.isEmpty() && stack.getItem() == Item.REGISTRY.getObject(new ResourceLocation(ModConfig.tweaks.endCake.fuel)) && fuelUntilFull != 0) {
             if (meta >= 0) {
                 world.setBlockState(pos, state.withProperty(BITES, meta), 2);
                 if (!player.capabilities.isCreativeMode) {

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockNetherCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockNetherCake.java
@@ -34,7 +34,9 @@ public class BlockNetherCake extends BlockCakeBase implements ITileEntityProvide
     public boolean onBlockActivated(World world, BlockPos pos, IBlockState state, EntityPlayer player, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
         int meta = getMetaFromState(world.getBlockState(pos)) - 1;
         ItemStack stack = player.getHeldItem(hand);
-        if (!stack.isEmpty() && stack.getItem() == Item.REGISTRY.getObject(new ResourceLocation(ModConfig.tweaks.netherCake.fuel))) {
+        int fuelUntilFull = getMetaFromState(state);
+
+        if (!stack.isEmpty() && stack.getItem() == Item.REGISTRY.getObject(new ResourceLocation(ModConfig.tweaks.netherCake.fuel)) && fuelUntilFull != 0) {
             if (meta >= 0) {
                 world.setBlockState(pos, state.withProperty(BITES, meta), 2);
                 if (!player.capabilities.isCreativeMode) {

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockNetherCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockNetherCake.java
@@ -1,26 +1,12 @@
 package jackyy.dimensionaledibles.block;
 
-import jackyy.dimensionaledibles.DimensionalEdibles;
-import jackyy.dimensionaledibles.block.tile.TileDimensionCake;
-import jackyy.dimensionaledibles.registry.ModConfig;
-import jackyy.dimensionaledibles.util.TeleporterHandler;
-import net.minecraft.block.ITileEntityProvider;
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumHand;
-import net.minecraft.util.NonNullList;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
+import jackyy.dimensionaledibles.*;
+import jackyy.dimensionaledibles.block.tile.*;
+import jackyy.dimensionaledibles.registry.*;
+import net.minecraft.block.*;
+import net.minecraft.tileentity.*;
+import net.minecraft.util.math.*;
+import net.minecraft.world.*;
 
 public class BlockNetherCake extends BlockCakeBase implements ITileEntityProvider {
 
@@ -31,72 +17,44 @@ public class BlockNetherCake extends BlockCakeBase implements ITileEntityProvide
     }
 
     @Override
-    public boolean onBlockActivated(World world, BlockPos pos, IBlockState state, EntityPlayer player, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
-        int meta = getMetaFromState(world.getBlockState(pos)) - 1;
-        ItemStack stack = player.getHeldItem(hand);
-        int fuelUntilFull = getMetaFromState(state);
-
-        if (!stack.isEmpty() && stack.getItem() == Item.REGISTRY.getObject(new ResourceLocation(ModConfig.tweaks.netherCake.fuel)) && fuelUntilFull != 0) {
-            if (meta >= 0) {
-                world.setBlockState(pos, state.withProperty(BITES, meta), 2);
-                if (!player.capabilities.isCreativeMode) {
-                    stack.shrink(1);
-                }
-                return true;
-            }
-        } else {
-            if (world.provider.getDimension() != -1) {
-                if (!world.isRemote) {
-                    if (player.capabilities.isCreativeMode || !ModConfig.tweaks.netherCake.consumeFuel) {
-                        teleportPlayer(world, player);
-                    } else {
-                        consumeCake(world, pos, player);
-                    }
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private void teleportPlayer(World world, EntityPlayer player) {
-        EntityPlayerMP playerMP = (EntityPlayerMP) player;
-        BlockPos coords;
-        if (ModConfig.tweaks.netherCake.useCustomCoords) {
-            coords = new BlockPos(ModConfig.tweaks.netherCake.customCoords.x, ModConfig.tweaks.netherCake.customCoords.y, ModConfig.tweaks.netherCake.customCoords.z);
-        } else {
-            coords = TeleporterHandler.getDimPos(playerMP, -1, player.getPosition());
-        }
-        TeleporterHandler.updateDimPos(playerMP, world.provider.getDimension(), player.getPosition());
-        TeleporterHandler.teleport(playerMP, -1, coords.getX(), coords.getY(), coords.getZ(), playerMP.server.getPlayerList());
-    }
-
-    private void consumeCake(World world, BlockPos pos, EntityPlayer player) {
-        if (player.canEat(true)) {
-            int l = world.getBlockState(pos).getValue(BITES);
-            if (l < 6) {
-                player.getFoodStats().addStats(2, 0.1F);
-                world.setBlockState(pos, world.getBlockState(pos).withProperty(BITES, l + 1), 3);
-                teleportPlayer(world, player);
-            }
-        }
+    public TileEntity createNewTileEntity(World worldIn,
+                                          int meta) {
+        return new TileDimensionCake(cakeDimension(), "Nether");
     }
 
     @Override
-    public IBlockState getStateForPlacement(World world, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer, EnumHand hand) {
-        return ModConfig.tweaks.netherCake.preFueled ? getDefaultState().withProperty(BITES, 0) : getDefaultState().withProperty(BITES, 6);
+    protected String cakeFuel() {
+        return ModConfig.tweaks.netherCake.fuel;
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
-    public void getSubBlocks(CreativeTabs tab, NonNullList<ItemStack> list) {
-        if (ModConfig.general.netherCake)
-            list.add(new ItemStack(this));
+    protected int cakeDimension() {
+        return -1;
     }
 
     @Override
-    public TileEntity createNewTileEntity(World worldIn, int meta) {
-        return new TileDimensionCake(-1, "Nether");
+    protected boolean consumesFuel() {
+        return ModConfig.tweaks.netherCake.consumeFuel;
     }
 
+    @Override
+    protected boolean useCustomCoordinates() {
+        return ModConfig.tweaks.netherCake.useCustomCoords;
+    }
+
+    @Override
+    protected BlockPos customCoordinates() {
+        return new BlockPos(ModConfig.tweaks.netherCake.customCoords.x,
+                            ModConfig.tweaks.netherCake.customCoords.y,
+                            ModConfig.tweaks.netherCake.customCoords.z);
+    }
+
+    @Override
+    protected boolean isPreFueled() {
+        return ModConfig.tweaks.netherCake.preFueled;
+    }
+
+    @Override boolean registerItem() {
+        return ModConfig.general.netherCake;
+    }
 }

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockOverworldCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockOverworldCake.java
@@ -35,7 +35,9 @@ public class BlockOverworldCake extends BlockCakeBase implements ITileEntityProv
     public boolean onBlockActivated(World world, BlockPos pos, IBlockState state, EntityPlayer player, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
         int meta = getMetaFromState(world.getBlockState(pos)) - 1;
         ItemStack stack = player.getHeldItem(hand);
-        if (!stack.isEmpty() && stack.getItem() == Item.REGISTRY.getObject(new ResourceLocation(ModConfig.tweaks.overworldCake.fuel))) {
+        int fuelUntilFull = getMetaFromState(state);
+
+        if (!stack.isEmpty() && stack.getItem() == Item.REGISTRY.getObject(new ResourceLocation(ModConfig.tweaks.overworldCake.fuel)) && fuelUntilFull != 0) {
             if (meta >= 0) {
                 world.setBlockState(pos, state.withProperty(BITES, meta), 2);
                 if (!player.capabilities.isCreativeMode) {

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockOverworldCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockOverworldCake.java
@@ -21,10 +21,10 @@ public class BlockOverworldCake extends BlockCakeBase implements ITileEntityProv
 
     @Override
     protected BlockPos calculateCoordinates(EntityPlayerMP player) {
-        WorldServer overworld = player.server.getPlayerList().getServerInstance().getWorld(cakeDimension());
-        if (ModConfig.tweaks.overworldCake.useWorldSpawn)
+        if (ModConfig.tweaks.overworldCake.useWorldSpawn) {
+            WorldServer overworld = player.server.getPlayerList().getServerInstance().getWorld(cakeDimension());
             return overworld.getTopSolidOrLiquidBlock(overworld.getSpawnPoint());
-        else
+        } else
             return getDimPos(player, cakeDimension(), player.getPosition());
     }
 

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockOverworldCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockOverworldCake.java
@@ -1,27 +1,15 @@
 package jackyy.dimensionaledibles.block;
 
-import jackyy.dimensionaledibles.DimensionalEdibles;
-import jackyy.dimensionaledibles.block.tile.TileDimensionCake;
-import jackyy.dimensionaledibles.registry.ModConfig;
-import jackyy.dimensionaledibles.util.TeleporterHandler;
-import net.minecraft.block.ITileEntityProvider;
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumHand;
-import net.minecraft.util.NonNullList;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
-import net.minecraft.world.WorldServer;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
+import jackyy.dimensionaledibles.*;
+import jackyy.dimensionaledibles.block.tile.*;
+import jackyy.dimensionaledibles.registry.*;
+import net.minecraft.block.*;
+import net.minecraft.entity.player.*;
+import net.minecraft.tileentity.*;
+import net.minecraft.util.math.*;
+import net.minecraft.world.*;
+
+import static jackyy.dimensionaledibles.util.TeleporterHandler.*;
 
 public class BlockOverworldCake extends BlockCakeBase implements ITileEntityProvider {
 
@@ -32,77 +20,53 @@ public class BlockOverworldCake extends BlockCakeBase implements ITileEntityProv
     }
 
     @Override
-    public boolean onBlockActivated(World world, BlockPos pos, IBlockState state, EntityPlayer player, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
-        int meta = getMetaFromState(world.getBlockState(pos)) - 1;
-        ItemStack stack = player.getHeldItem(hand);
-        int fuelUntilFull = getMetaFromState(state);
-
-        if (!stack.isEmpty() && stack.getItem() == Item.REGISTRY.getObject(new ResourceLocation(ModConfig.tweaks.overworldCake.fuel)) && fuelUntilFull != 0) {
-            if (meta >= 0) {
-                world.setBlockState(pos, state.withProperty(BITES, meta), 2);
-                if (!player.capabilities.isCreativeMode) {
-                    stack.shrink(1);
-                }
-                return true;
-            }
-        } else {
-            if (world.provider.getDimension() != 0) {
-                if (!world.isRemote) {
-                    if (player.capabilities.isCreativeMode || !ModConfig.tweaks.overworldCake.consumeFuel) {
-                        teleportPlayer(world, player);
-                    } else {
-                        consumeCake(world, pos, player);
-                    }
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private void teleportPlayer(World world, EntityPlayer player) {
-        EntityPlayerMP playerMP = (EntityPlayerMP) player;
-        BlockPos coords;
-        if (ModConfig.tweaks.overworldCake.useCustomCoords) {
-            coords = new BlockPos(ModConfig.tweaks.overworldCake.customCoords.x, ModConfig.tweaks.overworldCake.customCoords.y, ModConfig.tweaks.overworldCake.customCoords.z);
-        } else {
-            WorldServer overworld = playerMP.server.getPlayerList().getServerInstance().getWorld(0);
-            if (ModConfig.tweaks.overworldCake.useWorldSpawn) {
-                coords = overworld.getTopSolidOrLiquidBlock(overworld.getSpawnPoint());
-            } else {
-                coords = TeleporterHandler.getDimPos(playerMP, 0, player.getPosition());
-            }
-        }
-        TeleporterHandler.updateDimPos(playerMP, world.provider.getDimension(), player.getPosition());
-        TeleporterHandler.teleport(playerMP, 0, coords.getX(), coords.getY(), coords.getZ(), playerMP.server.getPlayerList());
-    }
-
-    private void consumeCake(World world, BlockPos pos, EntityPlayer player) {
-        if (player.canEat(true)) {
-            int l = world.getBlockState(pos).getValue(BITES);
-            if (l < 6) {
-                player.getFoodStats().addStats(2, 0.1F);
-                world.setBlockState(pos, world.getBlockState(pos).withProperty(BITES, l + 1), 3);
-                teleportPlayer(world, player);
-            }
-        }
+    protected BlockPos calculateCoordinates(EntityPlayerMP player) {
+        WorldServer overworld = player.server.getPlayerList().getServerInstance().getWorld(cakeDimension());
+        if (ModConfig.tweaks.overworldCake.useWorldSpawn)
+            return overworld.getTopSolidOrLiquidBlock(overworld.getSpawnPoint());
+        else
+            return getDimPos(player, cakeDimension(), player.getPosition());
     }
 
     @Override
-    public IBlockState getStateForPlacement(World world, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer, EnumHand hand) {
-        return ModConfig.tweaks.overworldCake.preFueled ? getDefaultState().withProperty(BITES, 0) : getDefaultState().withProperty(BITES, 6);
+    public TileEntity createNewTileEntity(World worldIn,
+                                          int meta) {
+        return new TileDimensionCake(cakeDimension(), "Overworld");
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
-    public void getSubBlocks(CreativeTabs tab, NonNullList<ItemStack> list) {
-        if (ModConfig.general.overworldCake)
-            list.add(new ItemStack(this));
+    protected String cakeFuel() {
+        return ModConfig.tweaks.overworldCake.fuel;
     }
 
     @Override
-    public TileEntity createNewTileEntity(World worldIn, int meta) {
-        return new TileDimensionCake(0, "Overworld");
+    protected boolean useCustomCoordinates() {
+        return ModConfig.tweaks.overworldCake.useCustomCoords;
     }
 
+    @Override
+    protected BlockPos customCoordinates() {
+        return new BlockPos(ModConfig.tweaks.overworldCake.customCoords.x,
+                            ModConfig.tweaks.overworldCake.customCoords.y,
+                            ModConfig.tweaks.overworldCake.customCoords.z);
+    }
+
+    @Override
+    protected int cakeDimension() {
+        return 0;
+    }
+
+    @Override
+    protected boolean consumesFuel() {
+        return ModConfig.tweaks.overworldCake.consumeFuel;
+    }
+
+    @Override
+    protected boolean isPreFueled() {
+        return ModConfig.tweaks.overworldCake.preFueled;
+    }
+
+    @Override boolean registerItem() {
+        return ModConfig.general.overworldCake;
+    }
 }

--- a/src/main/java/jackyy/dimensionaledibles/util/TeleporterHandler.java
+++ b/src/main/java/jackyy/dimensionaledibles/util/TeleporterHandler.java
@@ -27,6 +27,10 @@ import java.util.Random;
 
 public class TeleporterHandler {
 
+    public static void teleport(EntityPlayerMP player, int dim, BlockPos coords, PlayerList playerList) {
+        teleport(player, dim, coords.getX(), coords.getY(), coords.getZ(), playerList);
+    }
+
     public static void teleport(EntityPlayerMP player, int dim, double x, double y, double z, PlayerList playerList) {
         if (!ForgeHooks.onTravelToDimension(player, dim))
             return;


### PR DESCRIPTION
This PR allows for the cake to be used while holding the specified fuel block and the cake is at maximum fuel. Previously, the block would be placed into the world, if applicable.