### PR TITLE
Fix Ghost Block appearing when clicking on a cake

### DIFF
--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -145,18 +145,20 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
                     stack.shrink(1);
                 return true;
             }
-        } else if (worldIn.provider.getDimension() != this.cakeDimension())
+        } else if (worldIn.provider.getDimension() != this.cakeDimension()) {
             if (!worldIn.isRemote) {
                 if (playerIn.capabilities.isCreativeMode || !this.consumesFuel())
                     teleportPlayer(worldIn, playerIn);
                 else
                     consumeCake(worldIn, pos, playerIn);
-                return true;
             }
 
-        // Return true also on the client to make sure that MC knows we
-        // handled this and will not try to place a block on the client
-        return true;
+            // Return true also on the client to make sure that MC knows we
+            // handled this and will not try to place a block on the client
+            return true;
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -153,7 +153,10 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
                     consumeCake(worldIn, pos, playerIn);
                 return true;
             }
-        return false;
+
+        // Return true also on the client to make sure that MC knows we
+        // handled this and will not try to place a block on the client
+        return true;
     }
 
     @Override

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -146,15 +146,13 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
                 return true;
             }
         } else if (worldIn.provider.getDimension() != this.cakeDimension()) {
-            if (!worldIn.isRemote) {
+            if (!worldIn.isRemote)
                 if (playerIn.capabilities.isCreativeMode || !this.consumesFuel())
                     teleportPlayer(worldIn, playerIn);
                 else
                     consumeCake(worldIn, pos, playerIn);
-            }
 
-            // Return true also on the client to make sure that MC knows we
-            // handled this and will not try to place a block on the client
+            // client and server both need to report event was handled (Fixes #12)
             return true;
         }
 


### PR DESCRIPTION
In order to fix this issue, all I had to do was change the final return from false to true, to tell MC that we handled the `onBlockActivated()` call, ensuring that no block will be placed.

Closes #12