### PR TITLE
Some optimizations

### DIFF
--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -88,9 +88,11 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
     abstract protected int cakeDimension();
 
     /**
-     * Resource name of the fuel item for this cake.
+     * Item of the fuel item for this cake.
      */
-    abstract protected String cakeFuel();
+    // The efficiency of this method is best-case O(1), worst-case O(logN) due
+    // to the underlying implementation of the Item Registry using a HashMap
+    abstract protected ItemStack cakeFuel();
 
     /**
      * Whether this item should be registered.
@@ -137,7 +139,7 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
 
         ItemStack stack = playerIn.getHeldItem(hand);
         if (!stack.isEmpty() &&
-            stack.getItem() == Item.REGISTRY.getObject(new ResourceLocation(this.cakeFuel())) &&
+            ItemStack.areItemsEqual(stack, this.cakeFuel()) &&
             fuelUntilFull != 0) {
             if (meta >= 0) {
                 worldIn.setBlockState(pos, state.withProperty(BITES, meta), 2);

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
@@ -17,6 +17,8 @@ import net.minecraftforge.common.*;
 import net.minecraftforge.fml.relauncher.*;
 import org.apache.logging.log4j.*;
 
+import java.util.Objects;
+
 import static jackyy.dimensionaledibles.DimensionalEdibles.*;
 
 public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvider {
@@ -25,7 +27,7 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
     private int customY = 0;
     private int customZ = 0;
 
-    private String cakeFuel;
+    private ItemStack cakeFuel;
     private int cakeDimension = 0;
 
     public BlockCustomCake() {
@@ -80,7 +82,7 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
         }
     }
 
-    private String determineCakeFuel() {
+    private ItemStack determineCakeFuel() {
         String fuel = "minecraft:air";
         for(String s : ModConfig.tweaks.customEdible.customCake.fuel) {
             try {
@@ -98,7 +100,9 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
                            s + " is not a valid line input! The dimension ID needs to be a number!");
             }
         }
-        return fuel;
+
+        return new ItemStack(Objects.requireNonNull(
+                Item.REGISTRY.getObject(new ResourceLocation(fuel))));
     }
 
     @Override
@@ -145,7 +149,7 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
     }
 
     @Override
-    protected String cakeFuel() {
+    protected ItemStack cakeFuel() {
         return cakeFuel;
     }
 

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockEndCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockEndCake.java
@@ -4,9 +4,14 @@ import jackyy.dimensionaledibles.*;
 import jackyy.dimensionaledibles.block.tile.*;
 import jackyy.dimensionaledibles.registry.*;
 import net.minecraft.block.*;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.*;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.*;
 import net.minecraft.world.*;
+
+import java.util.Objects;
 
 public class BlockEndCake extends BlockCakeBase implements ITileEntityProvider {
 
@@ -23,8 +28,9 @@ public class BlockEndCake extends BlockCakeBase implements ITileEntityProvider {
     }
 
     @Override
-    protected String cakeFuel() {
-        return ModConfig.tweaks.endCake.fuel;
+    protected ItemStack cakeFuel() {
+        return new ItemStack(Objects.requireNonNull(
+                Item.REGISTRY.getObject(new ResourceLocation(ModConfig.tweaks.endCake.fuel))));
     }
 
     @Override

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockNetherCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockNetherCake.java
@@ -4,9 +4,14 @@ import jackyy.dimensionaledibles.*;
 import jackyy.dimensionaledibles.block.tile.*;
 import jackyy.dimensionaledibles.registry.*;
 import net.minecraft.block.*;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.*;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.*;
 import net.minecraft.world.*;
+
+import java.util.Objects;
 
 public class BlockNetherCake extends BlockCakeBase implements ITileEntityProvider {
 
@@ -23,8 +28,9 @@ public class BlockNetherCake extends BlockCakeBase implements ITileEntityProvide
     }
 
     @Override
-    protected String cakeFuel() {
-        return ModConfig.tweaks.netherCake.fuel;
+    protected ItemStack cakeFuel() {
+        return new ItemStack(Objects.requireNonNull(
+                Item.REGISTRY.getObject(new ResourceLocation(ModConfig.tweaks.netherCake.fuel))));
     }
 
     @Override

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockOverworldCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockOverworldCake.java
@@ -5,9 +5,14 @@ import jackyy.dimensionaledibles.block.tile.*;
 import jackyy.dimensionaledibles.registry.*;
 import net.minecraft.block.*;
 import net.minecraft.entity.player.*;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.*;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.*;
 import net.minecraft.world.*;
+
+import java.util.Objects;
 
 import static jackyy.dimensionaledibles.util.TeleporterHandler.*;
 
@@ -35,8 +40,9 @@ public class BlockOverworldCake extends BlockCakeBase implements ITileEntityProv
     }
 
     @Override
-    protected String cakeFuel() {
-        return ModConfig.tweaks.overworldCake.fuel;
+    protected ItemStack cakeFuel() {
+        return new ItemStack(Objects.requireNonNull(
+                Item.REGISTRY.getObject(new ResourceLocation(ModConfig.tweaks.overworldCake.fuel))));
     }
 
     @Override


### PR DESCRIPTION
As per the first section of #13, I changed `cakeFuel` to use an **ItemStack** instead of a String. I chose to do an ItemStack instead of an Item for two reasons:
- I needed an ItemStack to properly compare Item Metadata (which was before being completely ignored)
- I wanted to create the new ItemStack in `cakeFuel()` instead of `onBlockActivated()`, meaning better performance (slightly) if the config caching is implemented

I was not able to implement the suggested config optimizations, as I struggled with how to handle the event in the cake instances, as I couldn't see any reasonable way to do so from the static `onConfigChanged()` event handler. I did not want to have an instance of `BlockCakeBase` have an event handler for the same event as `onConfigChanged()` because I felt that could potentially cause a race condition where the Object finished its event handling before the static `onConfigChanged()` properly synced the config values. There is an event, `PostConfigChangedEvent` that may work, but the javadoc for it says it is intended for checking if config values for other mods have changed, so I decided not to use it.

As a result, the overall efficiency of `onBlockActivated()` is basically the same, but since the Item Registry lookup is in a HashMap, it is best-case O(1), worst-case O(N) (unrealistic) so this *may* still be okay, but this change at least now respects Item Metadata.