### PR TITLE
Switch to mavenCentral from JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ import groovyx.net.http.Method
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven { url = "http://files.minecraftforge.net/maven" }
     }
     dependencies {


### PR DESCRIPTION
Switches to mavenCentral from JCenter due to JCenter's eventual shutdown. Tested by switching the repository, cleaning cache, and then running setupDecompWorkspace again with no issues.