### PR TITLE
Check Fuel as an ItemStack

### DIFF
--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -112,7 +112,7 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
 
         ItemStack stack = playerIn.getHeldItem(hand);
         if (!stack.isEmpty() &&
-            stack.getItem() == Item.REGISTRY.getObject(new ResourceLocation(config().fuel())) &&
+            ItemStack.areItemsEqual(stack, getFuelItemStack()) &&
             fuelUntilFull != 0) {
             if (meta >= 0) {
                 worldIn.setBlockState(pos, state.withProperty(BITES, meta), 2);
@@ -280,6 +280,15 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
                 teleportPlayer(world, player);
             }
         }
+    }
+
+    /**
+     * Get the Cake Fuel as an ItemStack to maintain NBT data.
+     * @return The Fuel as an ItemStack
+     */
+    private ItemStack getFuelItemStack() {
+        return new ItemStack(Objects.requireNonNull(
+                Item.REGISTRY.getObject(new ResourceLocation(config().fuel()))));
     }
 
     @Override

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -289,11 +289,13 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
 
     /**
      * Get the Cake Fuel as an ItemStack to maintain NBT data and Metadata.
-     * @return The Fuel as an ItemStack
+     *
+     * @return The Fuel as an ItemStack if the Config entry is well-formed,
+     *         {@link #defaultFuel} otherwise.
      */
     private ItemStack getFuelItemStack() {
-        return new ItemStack(Objects.requireNonNull(
-                Item.REGISTRY.getObject(new ResourceLocation(config().fuel()))));
+        Item configItem = Item.REGISTRY.getObject(new ResourceLocation(config().fuel()));
+        return configItem == null ? defaultFuel() : new ItemStack(configItem);
     }
 
     @Override

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -20,6 +20,7 @@ import net.minecraft.util.text.*;
 import net.minecraft.world.*;
 import net.minecraftforge.fml.relauncher.*;
 
+import javax.annotation.*;
 import java.util.*;
 
 import static jackyy.dimensionaledibles.util.TeleporterHandler.*;
@@ -71,6 +72,10 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
 
     /** Whether this item should be registered. */
     abstract protected boolean registerItem();
+
+    /** The default fuel for this cake type, in the event of a configuration parse error. */
+    @Nonnull
+    abstract protected ItemStack defaultFuel();
 
     @Override
     public AxisAlignedBB getBoundingBox(IBlockState state,

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -283,7 +283,7 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
     }
 
     /**
-     * Get the Cake Fuel as an ItemStack to maintain NBT data.
+     * Get the Cake Fuel as an ItemStack to maintain NBT data and Metadata.
      * @return The Fuel as an ItemStack
      */
     private ItemStack getFuelItemStack() {

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
@@ -7,6 +7,7 @@ import net.minecraft.block.*;
 import net.minecraft.block.state.*;
 import net.minecraft.creativetab.*;
 import net.minecraft.entity.player.*;
+import net.minecraft.init.*;
 import net.minecraft.item.*;
 import net.minecraft.nbt.*;
 import net.minecraft.tileentity.*;
@@ -167,4 +168,8 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
 
     @Override
     public int cakeDimension() { return cakeDimension; }
+
+    @Override
+    @Nonnull
+    public ItemStack defaultFuel() { return ItemStack.EMPTY; }
 }

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockEndCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockEndCake.java
@@ -4,9 +4,12 @@ import jackyy.dimensionaledibles.*;
 import jackyy.dimensionaledibles.block.tile.*;
 import jackyy.dimensionaledibles.registry.*;
 import net.minecraft.block.*;
+import net.minecraft.init.*;
+import net.minecraft.item.*;
 import net.minecraft.tileentity.*;
-import net.minecraft.util.math.*;
 import net.minecraft.world.*;
+
+import javax.annotation.*;
 
 public class BlockEndCake extends BlockCakeBase implements ITileEntityProvider {
 
@@ -32,4 +35,8 @@ public class BlockEndCake extends BlockCakeBase implements ITileEntityProvider {
 
     @Override
     public boolean registerItem() { return ModConfig.general.endCake; }
+
+    @Nonnull
+    @Override
+    protected ItemStack defaultFuel() { return new ItemStack(Items.ENDER_EYE); }
 }

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockNetherCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockNetherCake.java
@@ -4,6 +4,8 @@ import jackyy.dimensionaledibles.*;
 import jackyy.dimensionaledibles.block.tile.*;
 import jackyy.dimensionaledibles.registry.*;
 import net.minecraft.block.*;
+import net.minecraft.init.*;
+import net.minecraft.item.*;
 import net.minecraft.tileentity.*;
 import net.minecraft.world.*;
 
@@ -31,4 +33,8 @@ public class BlockNetherCake extends BlockCakeBase implements ITileEntityProvide
 
     @Override
     public boolean registerItem() { return ModConfig.general.netherCake; }
+
+    @Nonnull
+    @Override
+    protected ItemStack defaultFuel() { return new ItemStack(Blocks.OBSIDIAN); }
 }

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockOverworldCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockOverworldCake.java
@@ -5,6 +5,8 @@ import jackyy.dimensionaledibles.block.tile.*;
 import jackyy.dimensionaledibles.registry.*;
 import net.minecraft.block.*;
 import net.minecraft.entity.player.*;
+import net.minecraft.init.*;
+import net.minecraft.item.*;
 import net.minecraft.tileentity.*;
 import net.minecraft.util.math.*;
 import net.minecraft.world.*;
@@ -48,4 +50,8 @@ public class BlockOverworldCake extends BlockCakeBase implements ITileEntityProv
 
     @Override
     public boolean registerItem() { return ModConfig.general.overworldCake; }
+
+    @Nonnull
+    @Override
+    protected ItemStack defaultFuel() { return new ItemStack(Blocks.SAPLING,1,0); } // Oak Sapling
 }


### PR DESCRIPTION
The remaining fix from #17 not included in the `config-refactor` branch was switching to using ItemStacks for fuel comparison. With this change, NBT data and metadata is properly respected for cake fuels.

For example, the Overworld Cake is set to `oakSapling` by default for its fuel. However, it would previously accept any Vanilla Sapling. Now it is explicitly Oak.

I left a method `BlockCakeBase#getFuelItemStack` as separate from the one place currently calling it, `BlockCakeBase#onBlockActivated` because I use this method again in the fuel tooltip.