### PR TITLE
Add Cake Fuel Tooltip

### DIFF
--- a/src/main/java/jackyy/dimensionaledibles/DimensionalEdibles.java
+++ b/src/main/java/jackyy/dimensionaledibles/DimensionalEdibles.java
@@ -1,5 +1,6 @@
 package jackyy.dimensionaledibles;
 
+import jackyy.dimensionaledibles.block.BlockCustomCake;
 import jackyy.dimensionaledibles.command.DimensionalEdiblesCommand;
 import jackyy.dimensionaledibles.proxy.CommonProxy;
 import jackyy.dimensionaledibles.registry.ModBlocks;
@@ -11,7 +12,14 @@ import net.minecraftforge.fml.common.event.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@Mod(modid = DimensionalEdibles.MODID, name = DimensionalEdibles.MODNAME, version = DimensionalEdibles.VERSION, acceptedMinecraftVersions = DimensionalEdibles.MCVERSION, dependencies = DimensionalEdibles.DEPENDS, certificateFingerprint = "@FINGERPRINT@", useMetadata = true)
+@Mod(modid = DimensionalEdibles.MODID,
+    name = DimensionalEdibles.MODNAME,
+    version = DimensionalEdibles.VERSION,
+    acceptedMinecraftVersions = DimensionalEdibles.MCVERSION,
+    dependencies = DimensionalEdibles.DEPENDS,
+    certificateFingerprint = "@FINGERPRINT@",
+    useMetadata = true)
+@SuppressWarnings("unused")
 public class DimensionalEdibles {
 
     public static final String VERSION = "GRADLE:VERSION";
@@ -33,6 +41,7 @@ public class DimensionalEdibles {
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event) {
         proxy.preInit(event);
+        BlockCustomCake.rebuildCache();
     }
 
     @Mod.EventHandler

--- a/src/main/java/jackyy/dimensionaledibles/DimensionalEdibles.java
+++ b/src/main/java/jackyy/dimensionaledibles/DimensionalEdibles.java
@@ -1,16 +1,14 @@
 package jackyy.dimensionaledibles;
 
-import jackyy.dimensionaledibles.block.BlockCustomCake;
-import jackyy.dimensionaledibles.command.DimensionalEdiblesCommand;
-import jackyy.dimensionaledibles.proxy.CommonProxy;
-import jackyy.dimensionaledibles.registry.ModBlocks;
-import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.item.ItemStack;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.SidedProxy;
+import jackyy.dimensionaledibles.block.*;
+import jackyy.dimensionaledibles.command.*;
+import jackyy.dimensionaledibles.proxy.*;
+import jackyy.dimensionaledibles.registry.*;
+import net.minecraft.creativetab.*;
+import net.minecraft.item.*;
+import net.minecraftforge.fml.common.*;
 import net.minecraftforge.fml.common.event.*;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.*;
 
 @Mod(modid = DimensionalEdibles.MODID,
     name = DimensionalEdibles.MODNAME,
@@ -56,7 +54,9 @@ public class DimensionalEdibles {
 
     @Mod.EventHandler
     public void onFingerprintViolation(FMLFingerprintViolationEvent event) {
-        logger.warn("Invalid fingerprint detected! The file " + event.getSource().getName() + " may have been modified. This will NOT be supported by the mod author!");
+        logger.warn(
+            "Invalid fingerprint detected! The file \"{}\" may have been modified. This will NOT be supported by the mod author!",
+            event.getSource().getName());
     }
 
     @Mod.EventHandler

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -112,7 +112,7 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
 
         ItemStack stack = playerIn.getHeldItem(hand);
         if (!stack.isEmpty() &&
-            stack.getItem() == Item.REGISTRY.getObject(new ResourceLocation(config().fuel())) &&
+            ItemStack.areItemsEqual(stack, getFuelItemStack()) &&
             fuelUntilFull != 0) {
             if (meta >= 0) {
                 worldIn.setBlockState(pos, state.withProperty(BITES, meta), 2);
@@ -280,6 +280,15 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
                 teleportPlayer(world, player);
             }
         }
+    }
+
+    /**
+     * Get the Cake Fuel as an ItemStack to maintain NBT data.
+     * @return The Fuel as an ItemStack
+     */
+    private ItemStack getFuelItemStack() {
+        return new ItemStack(Objects.requireNonNull(
+                Item.REGISTRY.getObject(new ResourceLocation(config().fuel()))));
     }
 
     @Override

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -1,6 +1,7 @@
 package jackyy.dimensionaledibles.block;
 
 import jackyy.dimensionaledibles.*;
+import jackyy.dimensionaledibles.item.*;
 import jackyy.dimensionaledibles.registry.*;
 import jackyy.dimensionaledibles.util.*;
 import mcjty.theoneprobe.api.*;
@@ -26,6 +27,7 @@ import javax.annotation.Nonnull;
 import java.util.*;
 
 import static jackyy.dimensionaledibles.util.TeleporterHandler.*;
+import static jackyy.dimensionaledibles.item.ItemBlockCustomCake.getDimID;
 
 /**
  * This is based on the vanilla cake class, but slightly modified and added
@@ -119,7 +121,7 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
 
         ItemStack stack = playerIn.getHeldItem(hand);
         if (!stack.isEmpty() &&
-            ItemStack.areItemsEqual(stack, getFuelItemStack()) &&
+            ItemStack.areItemsEqual(stack, getFuelItemStack(this.cakeDimension())) &&
             fuelUntilFull != 0) {
             if (meta >= 0) {
                 worldIn.setBlockState(pos, state.withProperty(BITES, meta), 2);
@@ -257,8 +259,8 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
                                   EntityPlayer player) {
         EntityPlayerMP playerMP = (EntityPlayerMP) player;
         BlockPos coords;
-        if (config().useCustomCoordinates())
-            coords = config().customCoords().toBlockPos();
+        if (config().useCustomCoordinates(this.cakeDimension()))
+            coords = config().customCoords(this.cakeDimension()).toBlockPos();
         else
             coords = calculateCoordinates(playerMP);
 
@@ -295,8 +297,8 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
      * @return The Fuel as an ItemStack if the Config entry is well-formed,
      *         {@link #defaultFuel} otherwise.
      */
-    private ItemStack getFuelItemStack() {
-        String fuel = config().fuel();
+    private ItemStack getFuelItemStack(int dim) {
+        String fuel = config().fuel(dim);
         if (fuel == null || fuel.equals(""))
             return defaultFuel();
 
@@ -316,12 +318,12 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
     @SideOnly(Side.CLIENT)
     public void addInformation(ItemStack stack, World worldIn, List<String> tooltip, ITooltipFlag flagIn) {
         super.addInformation(stack, worldIn, tooltip, flagIn);
-        ItemStack fuelStack = getFuelItemStack();
+        ItemStack fuelStack = getFuelItemStack(getDimID(stack));
         if (fuelStack == ItemStack.EMPTY)
             tooltip.add(I18n.format("tooltip.dimensionaledibles.custom_cake.bad_config"));
         else
             // Why do I need to add ".name"? Thank you Lex.
             tooltip.add(I18n.format("tooltip.dimensionaledibles.cake",
-                    I18n.format(getFuelItemStack().getTranslationKey() + ".name")));
+                    I18n.format(fuelStack.getTranslationKey() + ".name")));
     }
 }

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -296,7 +296,11 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
      *         {@link #defaultFuel} otherwise.
      */
     private ItemStack getFuelItemStack() {
-        Item configItem = Item.REGISTRY.getObject(new ResourceLocation(config().fuel()));
+        String fuel = config().fuel();
+        if (fuel == null || fuel.equals(""))
+            return defaultFuel();
+
+        Item configItem = Item.REGISTRY.getObject(new ResourceLocation(fuel));
         return configItem == null ? defaultFuel() : new ItemStack(configItem);
     }
 
@@ -314,7 +318,7 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
         super.addInformation(stack, worldIn, tooltip, flagIn);
         ItemStack fuelStack = getFuelItemStack();
         if (fuelStack == ItemStack.EMPTY)
-            tooltip.add("tooltip.dimensionaledibles.custom_cake.bad_config");
+            tooltip.add(I18n.format("tooltip.dimensionaledibles.custom_cake.bad_config"));
         else
             // Why do I need to add ".name"? Thank you Lex.
             tooltip.add(I18n.format("tooltip.dimensionaledibles.cake",

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -229,7 +229,7 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
                      .text(TextFormatting.GREEN + "Bites: ")
                      .progress(MAX_BITES - blockState.getValue(BITES), MAX_BITES);
             probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER))
-                     .item(getFuelItemStack(cakeDimension()))
+                     .item(fuelStack)
                      .text(TextFormatting.GREEN + "Refill: " + fuel);
         }
     }

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -229,7 +229,7 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
                      .text(TextFormatting.GREEN + "Bites: ")
                      .progress(MAX_BITES - blockState.getValue(BITES), MAX_BITES);
             probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER))
-                     .item(fuelStack)
+                     .item(fuelStack.isEmpty() ? new ItemStack(Blocks.BARRIER) : fuelStack)
                      .text(TextFormatting.GREEN + "Refill: " + fuel);
         }
     }

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -9,6 +9,8 @@ import net.minecraft.block.*;
 import net.minecraft.block.material.*;
 import net.minecraft.block.properties.*;
 import net.minecraft.block.state.*;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.creativetab.*;
 import net.minecraft.entity.*;
 import net.minecraft.entity.player.*;
@@ -20,6 +22,7 @@ import net.minecraft.util.text.*;
 import net.minecraft.world.*;
 import net.minecraftforge.fml.relauncher.*;
 
+import javax.annotation.Nullable;
 import java.util.*;
 
 import static jackyy.dimensionaledibles.util.TeleporterHandler.*;
@@ -297,5 +300,14 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
                              NonNullList<ItemStack> list) {
         if (registerItem())
             list.add(new ItemStack(this));
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> tooltip, ITooltipFlag flagIn) {
+        super.addInformation(stack, worldIn, tooltip, flagIn);
+        // Why do I need to add ".name"? Thank you Lex.
+        tooltip.add(I18n.format("tooltip.dimensionaledibles.cake",
+                I18n.format(getFuelItemStack().getTranslationKey() + ".name")));
     }
 }

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -22,7 +22,7 @@ import net.minecraft.util.text.*;
 import net.minecraft.world.*;
 import net.minecraftforge.fml.relauncher.*;
 
-import javax.annotation.*;
+import javax.annotation.Nonnull;
 import java.util.*;
 
 import static jackyy.dimensionaledibles.util.TeleporterHandler.*;
@@ -309,9 +309,8 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
     }
 
     @Override
-    @SuppressWarnings("all")
     @SideOnly(Side.CLIENT)
-    public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> tooltip, ITooltipFlag flagIn) {
+    public void addInformation(ItemStack stack, World worldIn, List<String> tooltip, ITooltipFlag flagIn) {
         super.addInformation(stack, worldIn, tooltip, flagIn);
         ItemStack fuelStack = getFuelItemStack();
         if (fuelStack == ItemStack.EMPTY)

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -303,11 +303,16 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
     }
 
     @Override
+    @SuppressWarnings("all")
     @SideOnly(Side.CLIENT)
     public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> tooltip, ITooltipFlag flagIn) {
         super.addInformation(stack, worldIn, tooltip, flagIn);
-        // Why do I need to add ".name"? Thank you Lex.
-        tooltip.add(I18n.format("tooltip.dimensionaledibles.cake",
-                I18n.format(getFuelItemStack().getTranslationKey() + ".name")));
+        ItemStack fuelStack = getFuelItemStack();
+        if (fuelStack == ItemStack.EMPTY)
+            tooltip.add("tooltip.dimensionaledibles.custom_cake.bad_config");
+        else
+            // Why do I need to add ".name"? Thank you Lex.
+            tooltip.add(I18n.format("tooltip.dimensionaledibles.cake",
+                    I18n.format(getFuelItemStack().getTranslationKey() + ".name")));
     }
 }

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -216,11 +216,21 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
                              World world,
                              IBlockState blockState,
                              IProbeHitData data) {
+
+        ItemStack fuelStack = getFuelItemStack(this.cakeDimension());
+        //Only the custom cake falls back to a default empty ItemStack, so if the ItemStack is empty, the cake is a
+        //custom cake with a bad fuel entry
+        String fuel = fuelStack.isEmpty() ? I18n.format("tooltip.dimensionaledibles.custom_cake.bad_config") :
+                I18n.format(fuelStack.getTranslationKey() + ".name");
+
         if (world.getBlockState(data.getPos()).getBlock() instanceof BlockCakeBase) {
             probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER))
                      .item(new ItemStack(Items.CAKE))
                      .text(TextFormatting.GREEN + "Bites: ")
                      .progress(MAX_BITES - blockState.getValue(BITES), MAX_BITES);
+            probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER))
+                     .item(getFuelItemStack(cakeDimension()))
+                     .text(TextFormatting.GREEN + "Refill: " + fuel);
         }
     }
 
@@ -229,9 +239,15 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
                                      List<String> currentTip,
                                      IWailaDataAccessor accessor,
                                      IWailaConfigHandler config) {
+
+        ItemStack fuelStack = getFuelItemStack(this.cakeDimension());
+        String fuel = fuelStack.isEmpty() ? I18n.format("tooltip.dimensionaledibles.custom_cake.bad_config") :
+                I18n.format(fuelStack.getTranslationKey() + ".name");
+
         if (accessor.getBlockState().getBlock() instanceof BlockCakeBase) {
             currentTip.add(TextFormatting.GRAY + "Bites: " +
                            (MAX_BITES - accessor.getBlockState().getValue(BITES)) + " / " + MAX_BITES);
+            currentTip.add(TextFormatting.GRAY + "Refill: " + fuel);
         }
         return currentTip;
     }

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -1,7 +1,6 @@
 package jackyy.dimensionaledibles.block;
 
 import jackyy.dimensionaledibles.*;
-import jackyy.dimensionaledibles.item.*;
 import jackyy.dimensionaledibles.registry.*;
 import jackyy.dimensionaledibles.util.*;
 import mcjty.theoneprobe.api.*;
@@ -10,8 +9,8 @@ import net.minecraft.block.*;
 import net.minecraft.block.material.*;
 import net.minecraft.block.properties.*;
 import net.minecraft.block.state.*;
-import net.minecraft.client.resources.I18n;
-import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.client.resources.*;
+import net.minecraft.client.util.*;
 import net.minecraft.creativetab.*;
 import net.minecraft.entity.*;
 import net.minecraft.entity.player.*;
@@ -23,11 +22,12 @@ import net.minecraft.util.text.*;
 import net.minecraft.world.*;
 import net.minecraftforge.fml.relauncher.*;
 
-import javax.annotation.Nonnull;
+import javax.annotation.*;
 import java.util.*;
 
+import static jackyy.dimensionaledibles.DimensionalEdibles.*;
+import static jackyy.dimensionaledibles.item.ItemBlockCustomCake.*;
 import static jackyy.dimensionaledibles.util.TeleporterHandler.*;
-import static jackyy.dimensionaledibles.item.ItemBlockCustomCake.getDimID;
 
 /**
  * This is based on the vanilla cake class, but slightly modified and added
@@ -315,9 +315,10 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
      */
     private ItemStack getFuelItemStack(int dim) {
         String fuel = config().fuel(dim);
-        if (fuel == null || fuel.equals(""))
+        if (fuel == null || fuel.equals("")) {
+            logger.error("Could not parse fuel for cake (dimension \"{}\"). Falling back to default fuel.", dim);
             return defaultFuel();
-
+        }
         Item configItem = Item.REGISTRY.getObject(new ResourceLocation(fuel));
         return configItem == null ? defaultFuel() : new ItemStack(configItem);
     }

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCakeBase.java
@@ -286,7 +286,7 @@ public abstract class BlockCakeBase extends Block implements ITOPInfoProvider, I
     }
 
     /**
-     * Get the Cake Fuel as an ItemStack to maintain NBT data.
+     * Get the Cake Fuel as an ItemStack to maintain NBT data and Metadata.
      * @return The Fuel as an ItemStack
      */
     private ItemStack getFuelItemStack() {

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
@@ -17,7 +17,6 @@ import net.minecraft.util.math.*;
 import net.minecraft.world.*;
 import net.minecraftforge.common.*;
 import net.minecraftforge.fml.relauncher.*;
-import org.apache.logging.log4j.*;
 
 import javax.annotation.*;
 
@@ -67,7 +66,7 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
 
         int dim = getDimension(world, pos);
         if(!cache.containsKey(dim)) {
-            logger.log(Level.ERROR, "No such dimension: " + dim);
+            logger.error("No such dimension: \"{}\"", dim);
             return true;
         }
 
@@ -102,13 +101,12 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
             try {
                 String[] parts = s.split(",");
                 if (parts.length < 4) {
-                    logger.log(Level.ERROR,
-                               s + " is not a valid input line! Format needs to be: <dimID>, <x>, <y>, <z>");
+                    logger.error("\"{}\" is not a valid input line! Format needs to be: <dimID>, <x>, <y>, <z>", s);
                     continue;
                 }
                 int dim = Integer.parseInt(parts[0].trim());
                 if(!newCache.containsKey(dim)) {
-                    logger.log(Level.ERROR, "Unrecognized dimension: \"" + dim + "\"");
+                    logger.error("Unrecognized dimension: \"{}\"", dim);
                     return;
                 }
                 CustomCake cake = newCache.get(dim);
@@ -119,8 +117,7 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
                 cc.z = Integer.parseInt(parts[3].trim());
 
             } catch(NumberFormatException e) {
-                logger.log(Level.ERROR,
-                           s + " is not a valid line input! The dimension ID needs to be a number!");
+                logger.error("\"{}\" is not a valid line input! The dimension ID needs to be a number!", s, e);
                 return;
             }
         }
@@ -129,8 +126,7 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
             try {
                 String[] parts = s.split(",");
                 if (parts.length < 2) {
-                    logger.log(Level.ERROR,
-                               s + " is not a valid input line! Format needs to be: <dimID>, <cakeFuel>");
+                    logger.error("\"{}\" is not a valid input line! Format needs to be: <dimID>, <cakeFuel>", s);
                     return;
                 }
                 int dim = Integer.parseInt(parts[0].trim());
@@ -138,8 +134,7 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
 
                 cake.cakeFuel = parts[1].trim();
             } catch(NumberFormatException e) {
-                logger.log(Level.ERROR,
-                           s + " is not a valid line input! The dimension ID needs to be a number!");
+                logger.error("\"{}\" is not a valid line input! The dimension ID needs to be a number!", s, e);
                 return;
             }
         }
@@ -157,8 +152,7 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
                 try {
                     String[] parts = s.split(",");
                     if (parts.length < 2) {
-                        logger.log(Level.ERROR,
-                                   s + " is not a valid input line! Format needs to be: <dimID>, <cakeName>");
+                        logger.error("\"{}\" is not a valid input line! Format needs to be: <dimID>, <cakeName>", s);
                         continue;
                     }
                     int dimension = Integer.parseInt(parts[0].trim());
@@ -173,11 +167,10 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
                         nbt.setString("cakeName", parts[1].trim());
                         list.add(stack);
                     } else {
-                        logger.log(Level.ERROR, parts[0] + " is not a valid dimension ID!");
+                        logger.error("\"{}\" is not a valid dimension ID!", parts[0]);
                     }
                 } catch(NumberFormatException e) {
-                    logger.log(Level.ERROR,
-                               s + " is not a valid line input! The dimension ID needs to be a number!");
+                    logger.error("\"{}\" is not a valid line input! The dimension ID needs to be a number!", s, e);
                 }
             }
         }

--- a/src/main/java/jackyy/dimensionaledibles/item/ItemBlockCustomCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/item/ItemBlockCustomCake.java
@@ -53,7 +53,7 @@ public class ItemBlockCustomCake extends ItemBlock {
         return nbt.getString("cakeName");
     }
 
-    public int getDimID(ItemStack stack) {
+    public static int getDimID(ItemStack stack) {
         NBTTagCompound nbt = stack.getTagCompound();
         if (nbt == null || !nbt.hasKey("dimID")) {
             return 0;

--- a/src/main/java/jackyy/dimensionaledibles/item/ItemBlockCustomCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/item/ItemBlockCustomCake.java
@@ -2,6 +2,7 @@ package jackyy.dimensionaledibles.item;
 
 import jackyy.dimensionaledibles.block.tile.TileDimensionCake;
 import jackyy.dimensionaledibles.registry.ModBlocks;
+import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.EnumRarity;
@@ -13,6 +14,10 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
 public class ItemBlockCustomCake extends ItemBlock {
 
     public ItemBlockCustomCake() {

--- a/src/main/java/jackyy/dimensionaledibles/item/ItemCustomApple.java
+++ b/src/main/java/jackyy/dimensionaledibles/item/ItemCustomApple.java
@@ -1,25 +1,27 @@
 package jackyy.dimensionaledibles.item;
 
-import jackyy.dimensionaledibles.DimensionalEdibles;
-import jackyy.dimensionaledibles.registry.ModConfig;
-import jackyy.dimensionaledibles.util.TeleporterHandler;
-import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.init.MobEffects;
-import net.minecraft.item.EnumRarity;
-import net.minecraft.item.ItemFood;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.potion.PotionEffect;
-import net.minecraft.util.NonNullList;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
-import net.minecraftforge.common.DimensionManager;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
-import org.apache.logging.log4j.Level;
+import jackyy.dimensionaledibles.*;
+import jackyy.dimensionaledibles.registry.*;
+import jackyy.dimensionaledibles.util.*;
+import mcp.*;
+import net.minecraft.creativetab.*;
+import net.minecraft.entity.player.*;
+import net.minecraft.init.*;
+import net.minecraft.item.*;
+import net.minecraft.nbt.*;
+import net.minecraft.potion.*;
+import net.minecraft.util.*;
+import net.minecraft.util.math.*;
+import net.minecraft.world.*;
+import net.minecraftforge.common.*;
+import net.minecraftforge.fml.relauncher.*;
 
+import javax.annotation.*;
+
+import static jackyy.dimensionaledibles.DimensionalEdibles.*;
+
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
 public class ItemCustomApple extends ItemFood {
 
     public ItemCustomApple() {
@@ -31,7 +33,9 @@ public class ItemCustomApple extends ItemFood {
     }
 
     @Override
-    public void onFoodEaten(ItemStack stack, World world, EntityPlayer player) {
+    public void onFoodEaten(ItemStack stack,
+                            World world,
+                            EntityPlayer player) {
         int dimension;
         NBTTagCompound nbt = stack.getTagCompound();
         if (nbt == null || !nbt.hasKey("dimID")) {
@@ -51,7 +55,12 @@ public class ItemCustomApple extends ItemFood {
                     coords = TeleporterHandler.getDimPos(playerMP, dimension, player.getPosition());
                 }
                 TeleporterHandler.updateDimPos(playerMP, world.provider.getDimension(), player.getPosition());
-                TeleporterHandler.teleport(playerMP, dimension, coords.getX(), coords.getY(), coords.getZ(), playerMP.server.getPlayerList());
+                TeleporterHandler.teleport(playerMP,
+                                           dimension,
+                                           coords.getX(),
+                                           coords.getY(),
+                                           coords.getZ(),
+                                           playerMP.server.getPlayerList());
                 player.addPotionEffect(new PotionEffect(MobEffects.RESISTANCE, 200, 200, false, false));
             }
         }
@@ -59,55 +68,61 @@ public class ItemCustomApple extends ItemFood {
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void getSubItems(CreativeTabs tab, NonNullList<ItemStack> list) {
+    public void getSubItems(CreativeTabs tab,
+                            NonNullList<ItemStack> list) {
         if (isInCreativeTab(tab)) {
             if (ModConfig.general.customApple) {
-                ItemStack stack;
-                for (String s : ModConfig.tweaks.customEdible.dimensions) {
-                    try {
-                        String[] parts = s.split(",");
-                        if (parts.length < 2) {
-                            DimensionalEdibles.logger.log(Level.ERROR, s + " is not a valid input line! Format needs to be: <dimID>, <cakeName>");
-                            continue;
-                        }
-                        int dimension = Integer.parseInt(parts[0]);
-                        if (DimensionManager.isDimensionRegistered(dimension)) {
-                            stack = new ItemStack(this);
-                            NBTTagCompound nbt = stack.getTagCompound();
-                            if (nbt == null) {
-                                nbt = new NBTTagCompound();
-                                stack.setTagCompound(nbt);
-                            }
-                            nbt.setInteger("dimID", dimension);
-                            nbt.setString("appleName", parts[1].trim());
-                            nbt.setInteger("x", 0);
-                            nbt.setInteger("y", 0);
-                            nbt.setInteger("z", 0);
-                            for (String c : ModConfig.tweaks.customEdible.customCoords) {
-                                try {
-                                    String[] coords = c.split(",");
-                                    if (coords.length < 4) {
-                                        DimensionalEdibles.logger.log(Level.ERROR, c + " is not a valid input line! Format needs to be: <dimID>, <x>, <y>, <z>");
-                                        continue;
-                                    }
-                                    if (Integer.parseInt(coords[0].trim()) == dimension) {
-                                        nbt.setInteger("x", Integer.parseInt(coords[1].trim()));
-                                        nbt.setInteger("y", Integer.parseInt(coords[2].trim()));
-                                        nbt.setInteger("z", Integer.parseInt(coords[3].trim()));
-                                    }
-                                } catch (NumberFormatException e) {
-                                    DimensionalEdibles.logger.log(Level.ERROR, c + " is not a valid line input! The dimension ID needs to be a number!");
-                                }
-                            }
-                            list.add(stack);
-                        } else {
-                            DimensionalEdibles.logger.log(Level.ERROR, parts[0] + " is not a valid dimension ID! (Needs to be a number)");
-                        }
-                    } catch (NumberFormatException e) {
-                        DimensionalEdibles.logger.log(Level.ERROR, s + " is not a valid line input! The dimension ID needs to be a number!");
-                    }
+                for(String s : ModConfig.tweaks.customEdible.dimensions) {
+                    parseSubItemsString(s, list);
                 }
             }
+        }
+    }
+
+    private void parseSubItemsString(String s,
+                                     NonNullList<ItemStack> list) {
+        ItemStack stack;
+        try {
+            String[] parts = s.split(",");
+            if (parts.length < 2) {
+                logger.error("{} is not a valid input line! Format needs to be: <dimID>, <cakeName>", s);
+                return;
+            }
+            int dimension = Integer.parseInt(parts[0]);
+            if (DimensionManager.isDimensionRegistered(dimension)) {
+                stack = new ItemStack(this);
+                NBTTagCompound nbt = stack.getTagCompound();
+                if (nbt == null) {
+                    nbt = new NBTTagCompound();
+                    stack.setTagCompound(nbt);
+                }
+                nbt.setInteger("dimID", dimension);
+                nbt.setString("appleName", parts[1].trim());
+                nbt.setInteger("x", 0);
+                nbt.setInteger("y", 0);
+                nbt.setInteger("z", 0);
+                for(String c : ModConfig.tweaks.customEdible.customCoords) {
+                    try {
+                        String[] coords = c.split(",");
+                        if (coords.length < 4) {
+                            logger.error("{} is not a valid input line! Format needs to be: <dimID>, <x>, <y>, <z>", c);
+                            continue;
+                        }
+                        if (Integer.parseInt(coords[0].trim()) == dimension) {
+                            nbt.setInteger("x", Integer.parseInt(coords[1].trim()));
+                            nbt.setInteger("y", Integer.parseInt(coords[2].trim()));
+                            nbt.setInteger("z", Integer.parseInt(coords[3].trim()));
+                        }
+                    } catch(NumberFormatException e) {
+                        logger.error("{} is not a valid line input! The dimension ID needs to be a number!", c, e);
+                    }
+                }
+                list.add(stack);
+            } else {
+                logger.error("{} is not a valid dimension ID! (Needs to be a number)", parts[0]);
+            }
+        } catch(NumberFormatException e) {
+            logger.error("{} is not a valid line input! The dimension ID needs to be a number!", s, e);
         }
     }
 

--- a/src/main/java/jackyy/dimensionaledibles/registry/ModConfig.java
+++ b/src/main/java/jackyy/dimensionaledibles/registry/ModConfig.java
@@ -1,12 +1,12 @@
 package jackyy.dimensionaledibles.registry;
 
-import jackyy.dimensionaledibles.DimensionalEdibles;
-import net.minecraft.util.math.BlockPos;
-import net.minecraftforge.common.config.Config;
-import net.minecraftforge.common.config.ConfigManager;
-import net.minecraftforge.fml.client.event.ConfigChangedEvent;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import jackyy.dimensionaledibles.*;
+import jackyy.dimensionaledibles.block.*;
+import net.minecraft.util.math.*;
+import net.minecraftforge.common.config.*;
+import net.minecraftforge.fml.client.event.*;
+import net.minecraftforge.fml.common.*;
+import net.minecraftforge.fml.common.eventhandler.*;
 
 @Config(modid = DimensionalEdibles.MODID, name = "DimensionalEdibles", category = DimensionalEdibles.MODID)
 public class ModConfig {
@@ -17,8 +17,11 @@ public class ModConfig {
     public static Tweaks tweaks = new Tweaks();
 
     public interface CakeConfig {
-        /** Resource name of the fuel item for this cake. */
-        String fuel();
+        /**
+         * Resource name of the fuel item for this cake.
+         * @param dim target dimension (ignored except for CustomEdible)
+         */
+        String fuel(int dim);
 
         /** Whether this cake comes pre-fueled (true) or starts empty (false) */
         boolean preFueled();
@@ -26,11 +29,17 @@ public class ModConfig {
         /** Whether this cake should consume fuel. */
         boolean consumesFuel();
 
-        /** Whether to use custom coordinates */
-        boolean useCustomCoordinates();
+        /**
+         *  Whether to use custom coordinates
+         * @param dim target dimension (ignored except for CustomEdible)
+         */
+        boolean useCustomCoordinates(int dim);
 
-        /** Custom Coordinates defined for this cake */
-        CustomCoords customCoords();
+        /**
+         * Custom Coordinates defined for this cake
+         * @param dim target dimension (ignored except for CustomEdible)
+         */
+        CustomCoords customCoords(int dim);
     }
 
     public static class General {
@@ -77,6 +86,11 @@ public class ModConfig {
         public BlockPos toBlockPos() {
             return new BlockPos(x, y, z);
         }
+
+        @Override
+        public String toString() {
+            return String.format("<%.2f,%.2f,%.2f>",x,y,z);
+        }
     }
 
     public static class Tweaks {
@@ -111,11 +125,11 @@ public class ModConfig {
             public CustomCoords customCoords = new CustomCoords();
 
             // boilerplate
-            public String fuel() { return fuel; }
+            public String fuel(int dim) { return fuel; }
             public boolean preFueled() { return preFueled; }
             public boolean consumesFuel() { return consumeFuel; }
-            public boolean useCustomCoordinates() { return useCustomCoords; }
-            public CustomCoords customCoords() { return customCoords; }
+            public boolean useCustomCoordinates(int dim) { return useCustomCoords; }
+            public CustomCoords customCoords(int dim) { return customCoords; }
         }
 
         public static class EnderApple {
@@ -138,11 +152,11 @@ public class ModConfig {
             public CustomCoords customCoords = new CustomCoords();
 
             // boilerplate
-            public String fuel() { return fuel; }
+            public String fuel(int dim) { return fuel; }
             public boolean preFueled() { return preFueled; }
             public boolean consumesFuel() { return consumeFuel; }
-            public boolean useCustomCoordinates() { return useCustomCoords; }
-            public CustomCoords customCoords() { return customCoords; }
+            public boolean useCustomCoordinates(int dim) { return useCustomCoords; }
+            public CustomCoords customCoords(int dim) { return customCoords; }
         }
 
         public static class NetherApple {
@@ -170,11 +184,11 @@ public class ModConfig {
             public CustomCoords customCoords = new CustomCoords();
 
             // boilerplate
-            public String fuel() { return fuel; }
+            public String fuel(int dim) { return fuel; }
             public boolean preFueled() { return preFueled; }
             public boolean consumesFuel() { return consumeFuel; }
-            public boolean useCustomCoordinates() { return useCustomCoords; }
-            public CustomCoords customCoords() { return customCoords; }
+            public boolean useCustomCoordinates(int dim) { return useCustomCoords; }
+            public CustomCoords customCoords(int dim) { return customCoords; }
         }
 
         public static class OverworldApple {
@@ -226,9 +240,11 @@ public class ModConfig {
     @Mod.EventBusSubscriber
     public static class ConfigHolder {
         @SubscribeEvent
+        @SuppressWarnings("unused")
         public static void onConfigChanged(ConfigChangedEvent.OnConfigChangedEvent event) {
             if (event.getModID().equals(DimensionalEdibles.MODID)) {
                 ConfigManager.sync(DimensionalEdibles.MODID, Config.Type.INSTANCE);
+                BlockCustomCake.rebuildCache();
             }
         }
     }

--- a/src/main/java/jackyy/dimensionaledibles/util/Cache.java
+++ b/src/main/java/jackyy/dimensionaledibles/util/Cache.java
@@ -1,0 +1,48 @@
+package jackyy.dimensionaledibles.util;
+
+import mcp.*;
+
+import javax.annotation.*;
+import java.util.*;
+import java.util.function.*;
+
+/**
+ * Specialization of HashMap which adds the ability to interact with fields of a potentially nonexistent key,
+ * using a lazily-evaluated fallback if the key does not exist.
+ *
+ * @param <K> Class of the map keys
+ * @param <V> Class of the map values
+ */
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+public class Cache<K, V> extends HashMap<K, V> {
+    /**
+     * @param key          the key of the map entry
+     * @param ifFunction   produces data from the value of the map entry if the key exists
+     * @param elseFunction produces the alternative result if the map contains no such key
+     * @param <T>          the type of value returned
+     * @return the value produced by {@code ifFunction} if the map contains an entry with the specified key, otherwise the
+     * result of {@code elseFunction.get()}.
+     */
+    public <T> T getPropertyIfPresentOrElse(K key,
+                                            Function<V, T> ifFunction,
+                                            Supplier<T> elseFunction) {
+        if (!this.containsKey(key))
+            return elseFunction.get();
+        return ifFunction.apply(this.get(key));
+    }
+
+    /**
+     * @param key        the key of the map entry
+     * @param ifFunction produces data from the value of the map entry if the key exists
+     * @param <T>        the type of value returned
+     * @return the value produced by {@code ifFunction} if the map contains an entry with the specified key,
+     * otherwise {@code null}.
+     * @see Cache#getPropertyIfPresentOrElse(Object, Function, Supplier)
+     */
+    @Nullable
+    public <T> T getPropertyIfPresentOrNull(K key,
+                                            Function<V, T> ifFunction) {
+        return this.getPropertyIfPresentOrElse(key, ifFunction, () -> null);
+    }
+}

--- a/src/main/resources/assets/dimensionaledibles/lang/en_US.lang
+++ b/src/main/resources/assets/dimensionaledibles/lang/en_US.lang
@@ -13,6 +13,9 @@ tile.dimensionaledibles.nether_cake.name=Nether Cake
 tile.dimensionaledibles.overworld_cake.name=Overworld Cake
 tile.dimensionaledibles.custom_cake.name=Custom Cake
 
+#Tooltip
+tooltip.dimensionaledibles.cake=§3§oRefill using %s.§r
+
 #JEI Compat
 dimensionaledibles.end_cake.jeidesc=Place the cake down and fill it with %d, then right click on the cake and you'll be teleported to The End. The cake has infinite uses as long as it is fueled.
 dimensionaledibles.nether_cake.jeidesc=Place the cake down and fill it with %d, then right click on the cake and you'll be teleported to the Nether. The cake has infinite uses as long as it is fueled.

--- a/src/main/resources/assets/dimensionaledibles/lang/en_US.lang
+++ b/src/main/resources/assets/dimensionaledibles/lang/en_US.lang
@@ -14,7 +14,8 @@ tile.dimensionaledibles.overworld_cake.name=Overworld Cake
 tile.dimensionaledibles.custom_cake.name=Custom Cake
 
 #Tooltip
-tooltip.dimensionaledibles.cake=§3§oRefill using %s.§r
+tooltip.dimensionaledibles.cake=§3§oRefill using %s.
+tooltip.dimensionaledibles.custom_cake.bad_config=§4Could not get Custom Cake fuel!
 
 #JEI Compat
 dimensionaledibles.end_cake.jeidesc=Place the cake down and fill it with %d, then right click on the cake and you'll be teleported to The End. The cake has infinite uses as long as it is fueled.


### PR DESCRIPTION
This commit is on top of PR #19, since it depends on the fuel being handled as an ItemStack, otherwise it gets an incorrect translation key when an Item uses NBT or metadata like Oak Saplings.

The tooltip follows the same formatting as is applied via scripts in Omnifactory:
![image](https://user-images.githubusercontent.com/10861407/111833870-c418f380-88c0-11eb-8cbe-96a3c3adc5d5.png)
