### PR TITLE
Address compatibility issues with JED dimensions

### DIFF
--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
@@ -16,7 +16,6 @@ import net.minecraft.util.*;
 import net.minecraft.util.math.*;
 import net.minecraft.util.text.*;
 import net.minecraft.world.*;
-import net.minecraftforge.fml.relauncher.*;
 import org.apache.logging.log4j.message.*;
 
 import javax.annotation.*;
@@ -149,7 +148,6 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
     public void getSubBlocks(CreativeTabs tab,
                              NonNullList<ItemStack> list) {
         if (registerItem()) {

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
@@ -14,13 +14,15 @@ import net.minecraft.nbt.*;
 import net.minecraft.tileentity.*;
 import net.minecraft.util.*;
 import net.minecraft.util.math.*;
+import net.minecraft.util.text.*;
 import net.minecraft.world.*;
 import net.minecraftforge.fml.relauncher.*;
+import org.apache.logging.log4j.message.*;
 
 import javax.annotation.*;
 
 import static jackyy.dimensionaledibles.DimensionalEdibles.*;
-import static net.minecraftforge.common.DimensionManager.isDimensionRegistered;
+import static net.minecraftforge.common.DimensionManager.*;
 
 public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvider {
 
@@ -63,8 +65,14 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
                                     float hitZ) {
 
         int dim = getDimension(world, pos);
-        if(!isDimensionRegistered(dim)) {
-            logger.error("Requested dimension: \"{}\" does not exist. Please verify your configs.", dim);
+        if (!isDimensionRegistered(dim)) {
+            Message message = new FormattedMessage(
+                "Requested dimension: \"{}\" does not exist. Please verify your configs.",
+                dim);
+            if (!world.isRemote)
+                logger.error(message);
+            else
+                player.sendMessage(new TextComponentString(message.getFormattedMessage()));
             return true;
         }
 

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
@@ -15,12 +15,12 @@ import net.minecraft.tileentity.*;
 import net.minecraft.util.*;
 import net.minecraft.util.math.*;
 import net.minecraft.world.*;
-import net.minecraftforge.common.*;
 import net.minecraftforge.fml.relauncher.*;
 
 import javax.annotation.*;
 
 import static jackyy.dimensionaledibles.DimensionalEdibles.*;
+import static net.minecraftforge.common.DimensionManager.isDimensionRegistered;
 
 public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvider {
 
@@ -62,11 +62,9 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
                                     float hitY,
                                     float hitZ) {
 
-
-
         int dim = getDimension(world, pos);
-        if(!cache.containsKey(dim)) {
-            logger.error("No such dimension: \"{}\"", dim);
+        if(!isDimensionRegistered(dim)) {
+            logger.error("Requested dimension: \"{}\" does not exist. Please verify your configs.", dim);
             return true;
         }
 
@@ -156,19 +154,18 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
                         continue;
                     }
                     int dimension = Integer.parseInt(parts[0].trim());
-                    if (DimensionManager.isDimensionRegistered(dimension)) {
-                        stack = new ItemStack(this);
-                        NBTTagCompound nbt = stack.getTagCompound();
-                        if (nbt == null) {
-                            nbt = new NBTTagCompound();
-                            stack.setTagCompound(nbt);
-                        }
-                        nbt.setInteger("dimID", dimension);
-                        nbt.setString("cakeName", parts[1].trim());
-                        list.add(stack);
-                    } else {
-                        logger.error("\"{}\" is not a valid dimension ID!", parts[0]);
+
+                    // Always register the requested cakes; JED dimensions may not be loaded yet
+                    stack = new ItemStack(this);
+                    NBTTagCompound nbt = stack.getTagCompound();
+                    if (nbt == null) {
+                        nbt = new NBTTagCompound();
+                        stack.setTagCompound(nbt);
                     }
+                    nbt.setInteger("dimID", dimension);
+                    nbt.setString("cakeName", parts[1].trim());
+                    list.add(stack);
+
                 } catch(NumberFormatException e) {
                     logger.error("\"{}\" is not a valid line input! The dimension ID needs to be a number!", s, e);
                 }

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
@@ -21,8 +21,8 @@ import org.apache.logging.log4j.message.*;
 
 import javax.annotation.*;
 
-import static jackyy.dimensionaledibles.DimensionalEdibles.*;
-import static net.minecraftforge.common.DimensionManager.*;
+import static jackyy.dimensionaledibles.DimensionalEdibles.logger;
+import static net.minecraftforge.common.DimensionManager.isDimensionRegistered;
 
 public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvider {
 


### PR DESCRIPTION
Fixes #22 by always registering configured custom cakes irrespective of whether the target dimension actually exists during FML initialization stages. Prevents players from actually eating the cake if the target dimension doesn't exist while the World is loaded, logging an error message to both the client and server that the configs need to be fixed.

It seems that a consequence of these changes is that existing Void Cakes (at least in my Omnifactory testing instance) disappeared from the world without warning. Perhaps it has something to do with actually registering the cake items properly rather than Omni's workaround of forcing JEI to list a cake with the expected NBT.

An extra benefit of this change is that now there's zero log spam about how Dim 119 doesn't exist during loading.