### PR TITLE
Implement workaround for fuel tooltip log spam bug

### DIFF
--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
@@ -239,11 +239,7 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
                              World world,
                              IBlockState blockState,
                              IProbeHitData data) {
-
-        int dim = getDimension(world, data.getPos());
-        if(!isDimensionRegistered(dim))
-            return;
-        this.cakeDimension = dim;
+        this.cakeDimension = getDimension(world, data.getPos());
         super.addProbeInfo(mode, probeInfo, player, world, blockState, data);
     }
 
@@ -252,10 +248,7 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
                                      List<String> currentTip,
                                      IWailaDataAccessor accessor,
                                      IWailaConfigHandler config) {
-        int dim = getDimension(accessor.getWorld(), accessor.getPosition());
-        if(!isDimensionRegistered(dim))
-            return Collections.emptyList();
-        this.cakeDimension = dim;
+        this.cakeDimension = getDimension(accessor.getWorld(), accessor.getPosition());
         return super.getWailaBody(itemStack, currentTip, accessor, config);
     }
 }

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
@@ -24,8 +24,8 @@ import javax.annotation.*;
 
 import java.util.*;
 
-import static jackyy.dimensionaledibles.DimensionalEdibles.*;
-import static net.minecraftforge.common.DimensionManager.*;
+import static jackyy.dimensionaledibles.DimensionalEdibles.logger;
+import static net.minecraftforge.common.DimensionManager.isDimensionRegistered;
 
 public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvider {
 

--- a/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
+++ b/src/main/java/jackyy/dimensionaledibles/block/BlockCustomCake.java
@@ -5,6 +5,8 @@ import jackyy.dimensionaledibles.block.tile.*;
 import jackyy.dimensionaledibles.item.*;
 import jackyy.dimensionaledibles.registry.*;
 import jackyy.dimensionaledibles.util.*;
+import mcjty.theoneprobe.api.*;
+import mcp.mobius.waila.api.*;
 import net.minecraft.block.*;
 import net.minecraft.block.state.*;
 import net.minecraft.creativetab.*;
@@ -20,8 +22,10 @@ import org.apache.logging.log4j.message.*;
 
 import javax.annotation.*;
 
-import static jackyy.dimensionaledibles.DimensionalEdibles.logger;
-import static net.minecraftforge.common.DimensionManager.isDimensionRegistered;
+import java.util.*;
+
+import static jackyy.dimensionaledibles.DimensionalEdibles.*;
+import static net.minecraftforge.common.DimensionManager.*;
 
 public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvider {
 
@@ -222,4 +226,36 @@ public class BlockCustomCake extends BlockCakeBase implements ITileEntityProvide
     @Override
     @Nonnull
     public ItemStack defaultFuel() { return ItemStack.EMPTY; }
+
+    /*
+        These overrides work around the bug causing log spam in tooltips when
+        looking at a cake. We should still consider splitting up custom cakes
+        into separate objects per dimension as hot-swapping state is brittle.
+     */
+    @Override
+    public void addProbeInfo(ProbeMode mode,
+                             IProbeInfo probeInfo,
+                             EntityPlayer player,
+                             World world,
+                             IBlockState blockState,
+                             IProbeHitData data) {
+
+        int dim = getDimension(world, data.getPos());
+        if(!isDimensionRegistered(dim))
+            return;
+        this.cakeDimension = dim;
+        super.addProbeInfo(mode, probeInfo, player, world, blockState, data);
+    }
+
+    @Override
+    public List<String> getWailaBody(ItemStack itemStack,
+                                     List<String> currentTip,
+                                     IWailaDataAccessor accessor,
+                                     IWailaConfigHandler config) {
+        int dim = getDimension(accessor.getWorld(), accessor.getPosition());
+        if(!isDimensionRegistered(dim))
+            return Collections.emptyList();
+        this.cakeDimension = dim;
+        return super.getWailaBody(itemStack, currentTip, accessor, config);
+    }
 }


### PR DESCRIPTION
Addresses the log spam bug #23 with a workaround that updates `BlockCustomCake.cakeDimension` in the TOP/WAILA rendering methods (similar to what we do in `onBlockActivated()`) so it has a value set before the superclass implementation of those methods try to access it.

In the longer term, a proper refactoring of custom cakes to avoid the state-swapping stuff is still desirable, so I don't want to link #23 and close it just yet.